### PR TITLE
Fix update_workspace overwriting metadata on settings-only changes

### DIFF
--- a/functions/chronomaps_api/__init__.py
+++ b/functions/chronomaps_api/__init__.py
@@ -534,14 +534,18 @@ def update_workspace(workspace):
         return value.lower() == 'true'
     key = flask.request.headers.get("Authorization")
     authenticate(workspace, key, ["admin"])
-    metadata = flask.request.json
+    metadata = flask.request.get_json(silent=True)
     public = flask.request.args.get("public", type=is_it_true)
     collaborate = flask.request.args.get("collaborate", type=is_it_true)
-    updates = {"metadata": metadata}
+    updates = {}
+    if metadata:
+        updates["metadata"] = metadata
     if public is not None:
         updates["config.public"] = public
     if collaborate is not None:
         updates["config.collaborate"] = collaborate
+    if not updates:
+        return {"message": "No updates provided"}, 400
     db.collection(workspace).document(".config").update(updates)
     return {"message": "Workspace updated", "updates": updates}, 200
 

--- a/functions/main.py
+++ b/functions/main.py
@@ -4,8 +4,9 @@ from firebase_admin.credentials import Certificate
 from firebase_functions.params import SecretParam
 from firebase_functions import https_fn, options, scheduler_fn
 from config import CONFIG__ITS_TIME, SERVICE_ACCOUNT_JSON
+from io import BytesIO
 import json
-import time 
+import time
 
 # serviceAccount = SecretParam('SERVICE_ACCOUNT_KEY').value
 # cred = credentials.Certificate(json.loads(serviceAccount)) if serviceAccount else None
@@ -27,7 +28,14 @@ CORS = options.CorsOptions(cors_origins="*", cors_methods=["get", "post"])
 # Expose Flask app as a single Cloud Function
 @https_fn.on_request(region='europe-west4', cors=options.CorsOptions(cors_origins="*", cors_methods=["post", "get", "put", "delete"]), secrets=['SERVICE_ACCOUNT_JSON'], memory=options.MemoryOption.MB_512)
 def chronomaps_api(req: https_fn.Request) -> https_fn.Response:
-    with chronomaps_api_app.request_context(req.environ):
+    # Pre-read body and cache it on the original request, then provide a fresh
+    # stream to the nested Flask context. This prevents the functions-framework's
+    # read_request after_request hook from crashing with ClientDisconnected when
+    # it tries to read an already-consumed wsgi.input stream.
+    body = req.get_data()
+    environ = req.environ.copy()
+    environ['wsgi.input'] = BytesIO(body)
+    with chronomaps_api_app.request_context(environ):
         return chronomaps_api_app.full_dispatch_request()
     
 @https_fn.on_request(region='europe-west4', cors=options.CorsOptions(cors_origins="*", cors_methods=["post"]), secrets=['OPENAI_API_KEY', 'CHRONOMAPS_API_URL'], memory=options.MemoryOption.MB_512)

--- a/functions/test_chronomaps_api.py
+++ b/functions/test_chronomaps_api.py
@@ -251,6 +251,38 @@ class TestWorkspaceEndpoints:
             assert "config" in data
             assert "keys" in data["config"]
 
+    def test_create_workspace_preserves_metadata(self, client, mock_db):
+        """Test that workspace creation stores the full request body as metadata."""
+        with patch('chronomaps_api.resolve_firebase_user.get_firebase_user_from_token') as mock_get_user:
+            mock_get_user.return_value = {"email": "test@example.com", "uid": "test-uid"}
+
+            mock_ref = Mock()
+            mock_db.collection.return_value.document.return_value = mock_ref
+
+            workspace_metadata = {
+                "title": "Future Scenarios 2050",
+                "description": "Workshop scenarios",
+                "event_name": "Workshop Jan 2025",
+                "default_moderation_level": 2,
+            }
+
+            response = client.post(
+                "/",
+                json=workspace_metadata,
+                content_type="application/json",
+                headers={"Authorization": "Bearer test-token"}
+            )
+
+            assert response.status_code == 201
+            data = json.loads(response.data)
+
+            # Verify metadata is in the response
+            assert data["config"]["metadata"] == workspace_metadata
+
+            # Verify metadata was written to Firestore
+            set_call = mock_ref.set.call_args[0][0]
+            assert set_call["metadata"] == workspace_metadata
+
     def test_get_workspace(self, client, mock_db, sample_workspace_config):
         """Test getting workspace metadata."""
         mock_ref = Mock()
@@ -282,6 +314,24 @@ class TestWorkspaceEndpoints:
         assert response.status_code == 200
         data = json.loads(response.data)
         assert "updates" in data
+
+    def test_update_workspace_settings_only(self, client, mock_db, sample_workspace_config):
+        """Test that updating only settings (public/collaborate) does not overwrite metadata."""
+        mock_ref = Mock()
+        mock_ref.get.return_value.to_dict.return_value = sample_workspace_config
+        mock_db.collection.return_value.document.return_value = mock_ref
+
+        response = client.put(
+            "/test-workspace?public=true&collaborate=true",
+            headers={"Authorization": sample_workspace_config["keys"]["admin"]},
+        )
+
+        assert response.status_code == 200
+        # Verify the Firestore update did NOT include metadata
+        update_call = mock_ref.update.call_args[0][0]
+        assert "metadata" not in update_call
+        assert update_call["config.public"] is True
+        assert update_call["config.collaborate"] is True
 
     def test_delete_workspace(self, client, mock_db, sample_workspace_config):
         """Test deleting workspace."""


### PR DESCRIPTION
## Summary
- **Main fix**: `update_workspace` unconditionally set `updates = {"metadata": metadata}` on every PUT, so changing only settings (`?public=true`) would overwrite stored metadata with `null`/`{}`, wiping workspace data. Now metadata is only included in the update when the request body actually contains data.
- **Secondary fix**: Pre-read the request body in the Cloud Function wrapper and provide a fresh `BytesIO` stream to the nested Flask context, preventing `ClientDisconnected` errors from the functions-framework's `read_request` after_request hook.
- Added tests for both workspace metadata preservation on create and settings-only updates.

## Test plan
- [x] All 37 existing + new tests pass
- [ ] Create a workspace with metadata via POST, then update settings via PUT without body — verify metadata is preserved
- [ ] Create a workspace with metadata via POST, then update metadata via PUT with body — verify metadata is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)