### PR TITLE
Add enhance_image API endpoint

### DIFF
--- a/functions/cluster_screenshots/calc_tsne.py
+++ b/functions/cluster_screenshots/calc_tsne.py
@@ -6,6 +6,7 @@ import requests
 import numpy as np
 from PIL import Image, ImageOps, ImageDraw, ImageFont
 from openai import OpenAI
+from enhance_image import enhance_image as enhance_image_fn, enhance, _normalize_url, STORAGE_BASE_URL
 
 from sklearn.manifold import TSNE
 from scipy.spatial.distance import cdist
@@ -97,38 +98,6 @@ def calc_tsne_grid(X_2d, out_dim):
     grid_jv = grid[col_asses]
     return grid_jv
 
-def white_patch(im: Image.Image,
-                white_pct: float = 90.0,   # “bright” threshold (percentile)
-                sat_thresh: float = 0.20    # drop coloured pixels
-               ) -> Image.Image:
-    """
-    White-balance a scanned page by forcing the brightest,
-    least-saturated pixels to 255 in every channel.
-    """
-    im = im.convert("RGB")
-    arr = np.asarray(im).astype(np.float32)
-
-    # 1. luminance & saturation
-    lum  = arr.mean(axis=2)                       # cheap grayscale
-    cmax = arr.max(axis=2);  cmin = arr.min(axis=2)
-    sat  = np.where(cmax > 0, (cmax - cmin) / cmax, 0)
-
-    # 2. pick candidate “paper” pixels
-    bright   = lum >= np.percentile(lum, white_pct)
-    neutral  = sat  < sat_thresh
-    mask     = bright & neutral
-
-    if not np.any(mask):                          # nothing found → fall back
-        mean   = arr.mean(axis=(0, 1))
-    else:
-        mean   = arr[mask].reshape(-1, 3).mean(axis=0)
-
-    # 3. linear scale so mean → 255
-    scale  = 255.0 / mean
-    result = np.clip(arr * scale, 0, 255).astype(np.uint8)
-
-    return Image.fromarray(result, "RGB")
-
 def gray_world(im: Image.Image) -> Image.Image:
     """
     Scale each RGB channel so that their means are equal
@@ -146,25 +115,13 @@ def gray_world(im: Image.Image) -> Image.Image:
     balanced = np.clip(arr * scale, 0, 255).astype(np.uint8)
     return Image.fromarray(balanced, "RGB")
 
-# ---------- 2.  Contrast stretch to common black/white points ----------
-def stretch_contrast(im: Image.Image,
-                     low_pct: float = 1.0,
-                     high_pct: float = 99.0) -> Image.Image:
-    """
-    Histogram-stretch so the low_pct / high_pct percentiles map to 0/255.
-    Keeps extreme outliers from blowing the image out.
-    """
-    return ImageOps.autocontrast(
-        im, cutoff=(low_pct, 100 - high_pct), preserve_tone=True
-    )                                            # Pillow ≥8.0 supports tuple cutoff
-
 def get_image(record, target_size, pos_x, pos_y, params: TSNEParams, save=None):
     # Open the image size, resize it to the target size (maintaining aspect ratio) and return a cropped image of the target size out the center
     metadata = dict()
     to_save = None
     if record is not None:
         filename = record.get('screenshot_url')
-        filename = filename.replace('https://storage.googleapis.com/chronomaps3.firebasestorage.app', 'https://storage.googleapis.com/chronomaps3-eu')
+        filename = _normalize_url(filename)
         rotate = record.get('plausibility') if isinstance(record.get('plausibility'), int) else 100
         rotate = int(rotate)
         rotate = (100 - rotate) / 100 * 32
@@ -196,26 +153,31 @@ def get_image(record, target_size, pos_x, pos_y, params: TSNEParams, save=None):
         img = _image.convert('RGB')
         img = img.resize(inner_target_size, Image.Resampling.LANCZOS)
     else:
-        side_ext = '' if params.SIDE == 1000 else f'.{params.SIDE}'
-        enhanced_filename = filename.replace('.jpeg', f'.enhanced{side_ext}.jpeg')
-        enhanced = True
-        try:
-            img = Image.open(requests.get(enhanced_filename, stream=True).raw)
-            metadata['url'] = enhanced_filename
-        except:
+        if not params.LOCAL:
+            result = enhance_image_fn(screenshot_url=filename, side=params.SIDE)
+            if isinstance(result, tuple):
+                # Error from enhance_image, fall back to original
+                try:
+                    img = Image.open(requests.get(filename, stream=True).raw)
+                except Exception as e:
+                    print('Error opening image:', filename)
+                    raise
+            else:
+                enhanced_url = result['enhanced_url']
+                metadata['url'] = enhanced_url
+                try:
+                    img = Image.open(requests.get(enhanced_url, stream=True).raw)
+                except Exception as e:
+                    print('Error opening enhanced image:', enhanced_url)
+                    raise
+        else:
             try:
                 img = Image.open(requests.get(filename, stream=True).raw)
-                enhanced = False
             except Exception as e:
                 print('Error opening image:', filename)
                 raise
-
-        if not enhanced:
-            img = white_patch(img)
-            img = stretch_contrast(img, low_pct=1, high_pct=99)
+            img = enhance(img)
             img = img.resize(inner_target_size, Image.Resampling.LANCZOS)
-            object_path = enhanced_filename.replace('https://storage.googleapis.com/chronomaps3-eu/', '')
-            to_save = img, object_path
 
         if record.get('workspace_title') and params.ADD_TITLE:
             img = ImageOps.expand(img, border=(0, 0, 0, 48), fill=params.BG_COLOR)  # Add a border around the image

--- a/functions/enhance_image/__init__.py
+++ b/functions/enhance_image/__init__.py
@@ -1,0 +1,139 @@
+from io import BytesIO
+
+import numpy as np
+from PIL import Image, ImageOps
+from firebase_admin import storage
+
+from config import BUCKET_NAME
+
+bucket = storage.bucket(name=BUCKET_NAME)
+
+STORAGE_BASE_URL = f'https://storage.googleapis.com/{BUCKET_NAME}/'
+LEGACY_STORAGE_BASE_URL = 'https://storage.googleapis.com/chronomaps3.firebasestorage.app/'
+
+
+def white_patch(im: Image.Image,
+                white_pct: float = 90.0,
+                sat_thresh: float = 0.20
+               ) -> Image.Image:
+    """
+    White-balance a scanned page by forcing the brightest,
+    least-saturated pixels to 255 in every channel.
+    """
+    im = im.convert("RGB")
+    arr = np.asarray(im).astype(np.float32)
+
+    lum  = arr.mean(axis=2)
+    cmax = arr.max(axis=2);  cmin = arr.min(axis=2)
+    sat  = np.where(cmax > 0, (cmax - cmin) / cmax, 0)
+
+    bright   = lum >= np.percentile(lum, white_pct)
+    neutral  = sat  < sat_thresh
+    mask     = bright & neutral
+
+    if not np.any(mask):
+        mean   = arr.mean(axis=(0, 1))
+    else:
+        mean   = arr[mask].reshape(-1, 3).mean(axis=0)
+
+    scale  = 255.0 / mean
+    result = np.clip(arr * scale, 0, 255).astype(np.uint8)
+
+    return Image.fromarray(result, "RGB")
+
+
+def stretch_contrast(im: Image.Image,
+                     low_pct: float = 1.0,
+                     high_pct: float = 99.0) -> Image.Image:
+    """
+    Histogram-stretch so the low_pct / high_pct percentiles map to 0/255.
+    """
+    return ImageOps.autocontrast(
+        im, cutoff=(low_pct, 100 - high_pct), preserve_tone=True
+    )
+
+
+def enhance(im: Image.Image) -> Image.Image:
+    """Apply white-patch balance and contrast stretch to an image."""
+    im = white_patch(im)
+    im = stretch_contrast(im, low_pct=1, high_pct=99)
+    return im
+
+
+def _normalize_url(url: str) -> str:
+    """Normalize legacy Firebase storage URLs to the current bucket URL."""
+    return url.replace(LEGACY_STORAGE_BASE_URL, STORAGE_BASE_URL)
+
+
+def _url_to_object_path(url: str) -> str:
+    """Convert a full storage URL to a storage object path.
+
+    Raises ValueError if the URL doesn't belong to our bucket.
+    """
+    url = _normalize_url(url)
+    if not url.startswith(STORAGE_BASE_URL):
+        raise ValueError(f'URL does not match storage bucket: {url}')
+    return url[len(STORAGE_BASE_URL):]
+
+
+def _enhanced_path(object_path: str, side: int = 1000) -> str:
+    """Derive the enhanced image object path from an original path."""
+    side_ext = '' if side == 1000 else f'.{side}'
+    return object_path.replace('.jpeg', f'.enhanced{side_ext}.jpeg')
+
+
+def enhance_image(screenshot_path: str = None, screenshot_url: str = None, side: int = 1000):
+    """Enhance a screenshot image if not already enhanced.
+
+    Accepts either a storage object path or a full URL. Checks if the
+    enhanced version exists; if not, downloads the original, enhances it,
+    and uploads the enhanced version.
+
+    Returns dict with enhanced_url, enhanced_path, and already_existed flag.
+    """
+    if not screenshot_path and not screenshot_url:
+        return dict(error='Either screenshot_path or screenshot_url is required'), 400
+
+    if screenshot_url:
+        try:
+            object_path = _url_to_object_path(screenshot_url)
+        except ValueError as e:
+            return dict(error=str(e)), 400
+    else:
+        object_path = screenshot_path
+
+    enhanced_object_path = _enhanced_path(object_path, side)
+
+    # Check if enhanced version already exists
+    enhanced_blob = bucket.blob(enhanced_object_path)
+    if enhanced_blob.exists():
+        enhanced_blob.make_public()
+        return dict(
+            enhanced_url=enhanced_blob.public_url,
+            enhanced_path=enhanced_object_path,
+            already_existed=True,
+        )
+
+    # Download original
+    original_blob = bucket.blob(object_path)
+    if not original_blob.exists():
+        return dict(error=f'Original image not found: {object_path}'), 404
+
+    image_bytes = original_blob.download_as_bytes()
+    img = Image.open(BytesIO(image_bytes))
+
+    # Enhance
+    img = enhance(img)
+
+    # Upload enhanced
+    buff = BytesIO()
+    img.save(buff, format='jpeg', quality=90, optimize=True, progressive=True)
+    buff.seek(0)
+    enhanced_blob.upload_from_file(buff, content_type='image/jpeg')
+    enhanced_blob.make_public()
+
+    return dict(
+        enhanced_url=enhanced_blob.public_url,
+        enhanced_path=enhanced_object_path,
+        already_existed=False,
+    )

--- a/functions/enhance_image/__init__.py
+++ b/functions/enhance_image/__init__.py
@@ -82,14 +82,38 @@ def _enhanced_path(object_path: str, side: int = 1000) -> str:
     return object_path.replace('.jpeg', f'.enhanced{side_ext}.jpeg')
 
 
-def enhance_image(screenshot_path: str = None, screenshot_url: str = None, side: int = 1000):
-    """Enhance a screenshot image if not already enhanced.
+def _thumbnail_path(object_path: str, size: int = 200) -> str:
+    """Derive the thumbnail image object path from an original path."""
+    size_ext = '' if size == 200 else f'.{size}'
+    return object_path.replace('.jpeg', f'.thumbnail{size_ext}.jpeg')
+
+
+def _create_thumbnail(img: Image.Image, size: int = 200) -> Image.Image:
+    """Create a thumbnail from an image, preserving aspect ratio."""
+    thumb = img.copy()
+    thumb.thumbnail((size, size), Image.Resampling.LANCZOS)
+    return thumb
+
+
+def _upload_image(blob, img: Image.Image, quality: int = 90):
+    """Save a PIL image to a storage blob as JPEG."""
+    buff = BytesIO()
+    img.save(buff, format='jpeg', quality=quality, optimize=True, progressive=True)
+    buff.seek(0)
+    blob.upload_from_file(buff, content_type='image/jpeg')
+    blob.make_public()
+
+
+def enhance_image(screenshot_path: str = None, screenshot_url: str = None, side: int = 1000, thumbnail_size: int = 200):
+    """Enhance a screenshot image and create a thumbnail.
 
     Accepts either a storage object path or a full URL. Checks if the
     enhanced version exists; if not, downloads the original, enhances it,
-    and uploads the enhanced version.
+    and uploads the enhanced version. Also creates a thumbnail from the
+    enhanced image if one doesn't exist yet.
 
-    Returns dict with enhanced_url, enhanced_path, and already_existed flag.
+    Returns dict with enhanced_url, enhanced_path, thumbnail_url,
+    thumbnail_path, and already_existed flag.
     """
     if not screenshot_path and not screenshot_url:
         return dict(error='Either screenshot_path or screenshot_url is required'), 400
@@ -103,37 +127,44 @@ def enhance_image(screenshot_path: str = None, screenshot_url: str = None, side:
         object_path = screenshot_path
 
     enhanced_object_path = _enhanced_path(object_path, side)
+    thumb_object_path = _thumbnail_path(object_path, thumbnail_size)
 
     # Check if enhanced version already exists
     enhanced_blob = bucket.blob(enhanced_object_path)
-    if enhanced_blob.exists():
+    enhanced_existed = enhanced_blob.exists()
+
+    if enhanced_existed:
         enhanced_blob.make_public()
-        return dict(
-            enhanced_url=enhanced_blob.public_url,
-            enhanced_path=enhanced_object_path,
-            already_existed=True,
-        )
+        enhanced_img = None
+    else:
+        # Download original
+        original_blob = bucket.blob(object_path)
+        if not original_blob.exists():
+            return dict(error=f'Original image not found: {object_path}'), 404
 
-    # Download original
-    original_blob = bucket.blob(object_path)
-    if not original_blob.exists():
-        return dict(error=f'Original image not found: {object_path}'), 404
+        image_bytes = original_blob.download_as_bytes()
+        img = Image.open(BytesIO(image_bytes))
 
-    image_bytes = original_blob.download_as_bytes()
-    img = Image.open(BytesIO(image_bytes))
+        # Enhance and upload
+        enhanced_img = enhance(img)
+        _upload_image(enhanced_blob, enhanced_img)
 
-    # Enhance
-    img = enhance(img)
-
-    # Upload enhanced
-    buff = BytesIO()
-    img.save(buff, format='jpeg', quality=90, optimize=True, progressive=True)
-    buff.seek(0)
-    enhanced_blob.upload_from_file(buff, content_type='image/jpeg')
-    enhanced_blob.make_public()
+    # Create thumbnail from enhanced image if it doesn't exist
+    thumb_blob = bucket.blob(thumb_object_path)
+    if not thumb_blob.exists():
+        if enhanced_img is None:
+            # Need to download the enhanced image to create thumbnail
+            enhanced_bytes = enhanced_blob.download_as_bytes()
+            enhanced_img = Image.open(BytesIO(enhanced_bytes))
+        thumb = _create_thumbnail(enhanced_img, thumbnail_size)
+        _upload_image(thumb_blob, thumb, quality=85)
+    else:
+        thumb_blob.make_public()
 
     return dict(
         enhanced_url=enhanced_blob.public_url,
         enhanced_path=enhanced_object_path,
-        already_existed=False,
+        thumbnail_url=thumb_blob.public_url,
+        thumbnail_path=thumb_object_path,
+        already_existed=enhanced_existed,
     )

--- a/functions/enhance_image/__init__.py
+++ b/functions/enhance_image/__init__.py
@@ -1,3 +1,4 @@
+import re
 from io import BytesIO
 
 import numpy as np
@@ -167,4 +168,46 @@ def enhance_image(screenshot_path: str = None, screenshot_url: str = None, side:
         thumbnail_url=thumb_blob.public_url,
         thumbnail_path=thumb_object_path,
         already_existed=enhanced_existed,
+    )
+
+
+# Pattern matching original screenshots: workspace/item_id/screenshot.jpeg
+# Excludes .enhanced. and .thumbnail. variants
+_ORIGINAL_PATTERN = re.compile(r'^[^/]+/[^/]+/screenshot\.jpeg$')
+
+
+def enhance_all_images(side: int = 1000, thumbnail_size: int = 200):
+    """Iterate over all original screenshots in storage and ensure
+    each has an enhanced version and a thumbnail.
+
+    Yields status dicts for each image processed.
+    """
+    processed = 0
+    enhanced_count = 0
+    errors = 0
+
+    for blob in bucket.list_blobs():
+        path = blob.name
+        if not _ORIGINAL_PATTERN.match(path):
+            continue
+
+        processed += 1
+        try:
+            result = enhance_image(screenshot_path=path, side=side, thumbnail_size=thumbnail_size)
+            if isinstance(result, tuple):
+                errors += 1
+                yield dict(msg=f'Error processing {path}: {result[0]["error"]}')
+            else:
+                if not result['already_existed']:
+                    enhanced_count += 1
+                yield dict(msg=f'Processed {path} (new={not result["already_existed"]})')
+        except Exception as e:
+            errors += 1
+            yield dict(msg=f'Exception processing {path}: {e}')
+
+    yield dict(
+        msg=f'Done. Processed: {processed}, newly enhanced: {enhanced_count}, errors: {errors}',
+        processed=processed,
+        enhanced=enhanced_count,
+        errors=errors,
     )

--- a/functions/functions.yaml
+++ b/functions/functions.yaml
@@ -86,6 +86,39 @@ endpoints:
     - key: CHRONOMAPS_API_URL
     serviceAccountEmail: null
     timeoutSeconds: null
+  replace_image:
+    availableMemoryMb: 512
+    concurrency: null
+    entryPoint: replace_image
+    httpsTrigger: {}
+    ingressSettings: null
+    labels: {}
+    maxInstances: null
+    minInstances: null
+    platform: gcfv2
+    region:
+    - europe-west4
+    secretEnvironmentVariables:
+    - key: CHRONOMAPS_API_URL
+    serviceAccountEmail: null
+    timeoutSeconds: null
+  reanalyze_item:
+    availableMemoryMb: 512
+    concurrency: null
+    entryPoint: reanalyze_item
+    httpsTrigger: {}
+    ingressSettings: null
+    labels: {}
+    maxInstances: null
+    minInstances: null
+    platform: gcfv2
+    region:
+    - europe-west4
+    secretEnvironmentVariables:
+    - key: OPENAI_API_KEY
+    - key: CHRONOMAPS_API_URL
+    serviceAccountEmail: null
+    timeoutSeconds: null
   complete_flow:
     availableMemoryMb: 512
     concurrency: null
@@ -102,10 +135,64 @@ endpoints:
     - key: CHRONOMAPS_API_URL
     serviceAccountEmail: null
     timeoutSeconds: null
+  enhance_image:
+    availableMemoryMb: 512
+    concurrency: null
+    entryPoint: enhance_image
+    httpsTrigger: {}
+    ingressSettings: null
+    labels: {}
+    maxInstances: null
+    minInstances: null
+    platform: gcfv2
+    region:
+    - europe-west4
+    secretEnvironmentVariables:
+    - key: SERVICE_ACCOUNT_JSON
+    serviceAccountEmail: null
+    timeoutSeconds: null
+  enhance_all:
+    availableMemoryMb: 1024
+    concurrency: null
+    entryPoint: enhance_all
+    httpsTrigger: {}
+    ingressSettings: null
+    labels: {}
+    maxInstances: null
+    minInstances: null
+    platform: gcfv2
+    region:
+    - europe-west4
+    secretEnvironmentVariables:
+    - key: SERVICE_ACCOUNT_JSON
+    serviceAccountEmail: null
+    timeoutSeconds: 540
+  enhance_all_daily:
+    availableMemoryMb: 1024
+    concurrency: null
+    entryPoint: enhance_all_daily
+    ingressSettings: null
+    labels: {}
+    maxInstances: null
+    minInstances: null
+    platform: gcfv2
+    region:
+    - europe-west1
+    scheduleTrigger:
+      retryConfig: {}
+      schedule: every day 03:00
+    secretEnvironmentVariables:
+    - key: SERVICE_ACCOUNT_JSON
+    serviceAccountEmail: null
+    timeoutSeconds: 540
 params:
 - name: OPENAI_API_KEY
   type: secret
 - name: CHRONOMAPS_API_URL
+  type: secret
+- name: SERVICE_ACCOUNT_JSON
+  type: secret
+- name: CONFIG__ITS_TIME
   type: secret
 requiredAPIs:
 - api: cloudscheduler.googleapis.com

--- a/functions/main.py
+++ b/functions/main.py
@@ -24,6 +24,7 @@ from screenshot_handler import reanalyze_item as reanalyze_item_fn
 from item_ingress_agent import item_ingress_agent as item_ingress_agent_fn
 from cluster_screenshots import cluster_screenshots_all as cluster_screenshots_fn
 from enhance_image import enhance_image as enhance_image_fn
+from enhance_image import enhance_all_images as enhance_all_images_fn
 from complete_flow import complete_flow as complete_flow_fn
 
 CORS = options.CorsOptions(cors_origins="*", cors_methods=["get", "post"])
@@ -162,6 +163,23 @@ def cluster_screenshots(req: https_fn.Request) -> https_fn.Response:
             yield f"data: {json.dumps(bit, ensure_ascii=False)}\n\n"
     return https_fn.Response(generate(), status=200, mimetype='text/event-stream')
 
+
+@scheduler_fn.on_schedule(region='europe-west1', schedule="every day 03:00", secrets=['SERVICE_ACCOUNT_JSON'], memory=options.MemoryOption.GB_1, timeout_sec=540)
+def enhance_all_daily(event: scheduler_fn.ScheduledEvent) -> None:
+    print("STARTING daily enhancement backfill")
+    for bit in enhance_all_images_fn():
+        print(json.dumps(bit, ensure_ascii=False))
+
+@https_fn.on_request(region='europe-west4', cors=options.CorsOptions(cors_origins="*", cors_methods=["post"]), secrets=['SERVICE_ACCOUNT_JSON'], memory=options.MemoryOption.GB_1, timeout_sec=540)
+def enhance_all(req: https_fn.Request) -> https_fn.Response:
+    side = req.args.get('side', 1000, type=int)
+    thumbnail_size = req.args.get('thumbnail_size', 200, type=int)
+    start = time.time()
+    def generate():
+        for bit in enhance_all_images_fn(side=side, thumbnail_size=thumbnail_size):
+            delta = int(time.time() - start)
+            yield f"data: {json.dumps([delta, bit], ensure_ascii=False)}\n\n"
+    return https_fn.Response(generate(), status=200, mimetype='text/event-stream')
 
 @scheduler_fn.on_schedule(region='europe-west1', schedule="every 15 minutes", secrets=['CHRONOMAPS_API_URL', 'OPENAI_API_KEY', 'CONFIG__ITS_TIME'], memory=options.MemoryOption.GB_8)
 def cluster_its_time(event: scheduler_fn.ScheduledEvent) -> None:

--- a/functions/main.py
+++ b/functions/main.py
@@ -137,9 +137,10 @@ def enhance_image(req: https_fn.Request) -> https_fn.Response:
     screenshot_path = req.args.get('path')
     screenshot_url = req.args.get('url')
     side = req.args.get('side', 1000, type=int)
+    thumbnail_size = req.args.get('thumbnail_size', 200, type=int)
     if not screenshot_path and not screenshot_url:
         return https_fn.Response("Missing path or url parameter", status=400)
-    result = enhance_image_fn(screenshot_path=screenshot_path, screenshot_url=screenshot_url, side=side)
+    result = enhance_image_fn(screenshot_path=screenshot_path, screenshot_url=screenshot_url, side=side, thumbnail_size=thumbnail_size)
     if isinstance(result, tuple):
         return json.dumps(result[0]), result[1]
     return json.dumps(result)

--- a/functions/main.py
+++ b/functions/main.py
@@ -23,6 +23,7 @@ from screenshot_handler import replace_item_image as replace_item_image_fn
 from screenshot_handler import reanalyze_item as reanalyze_item_fn
 from item_ingress_agent import item_ingress_agent as item_ingress_agent_fn
 from cluster_screenshots import cluster_screenshots_all as cluster_screenshots_fn
+from enhance_image import enhance_image as enhance_image_fn
 from complete_flow import complete_flow as complete_flow_fn
 
 CORS = options.CorsOptions(cors_origins="*", cors_methods=["get", "post"])
@@ -130,6 +131,18 @@ def item_ingress_agent(req: https_fn.Request) -> https_fn.Response:
             print(json.dumps(bit, ensure_ascii=False))
         # Return the result as a JSON response
         return dict(status='ok')
+
+@https_fn.on_request(region='europe-west4', cors=options.CorsOptions(cors_origins="*", cors_methods=["post"]), secrets=['SERVICE_ACCOUNT_JSON'], memory=options.MemoryOption.MB_512)
+def enhance_image(req: https_fn.Request) -> https_fn.Response:
+    screenshot_path = req.args.get('path')
+    screenshot_url = req.args.get('url')
+    side = req.args.get('side', 1000, type=int)
+    if not screenshot_path and not screenshot_url:
+        return https_fn.Response("Missing path or url parameter", status=400)
+    result = enhance_image_fn(screenshot_path=screenshot_path, screenshot_url=screenshot_url, side=side)
+    if isinstance(result, tuple):
+        return json.dumps(result[0]), result[1]
+    return json.dumps(result)
 
 @https_fn.on_request(region='europe-west4', cors=options.CorsOptions(cors_origins="*", cors_methods=["post"]), secrets=['CHRONOMAPS_API_URL', 'OPENAI_API_KEY'], memory=options.MemoryOption.GB_8)
 def cluster_screenshots(req: https_fn.Request) -> https_fn.Response:

--- a/functions/screenshot_handler/__init__.py
+++ b/functions/screenshot_handler/__init__.py
@@ -3,6 +3,7 @@ from openai import OpenAI
 from firebase_admin import storage
 from pathlib import Path
 from config import OPENAI_KEY, CHRONOMAPS_API_URL, BUCKET_NAME, PRIVATE_KEY
+from enhance_image import enhance_image as enhance_image_fn
 import os
 import base64
 import json
@@ -205,6 +206,11 @@ def screenshot_handler(image_bytes, workspace, api_key, automatic=False, image_c
 
     screenshot_url = upload_image(image_bytes, image_content_type, workspace, item_id)
 
+    # Pre-generate enhanced version for faster TSNE processing later
+    enhanced_result = enhance_image_fn(screenshot_url=screenshot_url)
+    if isinstance(enhanced_result, tuple):
+        print('WARNING: failed to enhance image:', enhanced_result[0])
+
     record_ = {'screenshot_url': screenshot_url}
     err = update_item(workspace, item_id, item_key, api_key, record_)
     if err:
@@ -227,6 +233,11 @@ def replace_item_image(image_bytes, image_content_type, workspace, item_id, item
         return result
 
     screenshot_url = upload_image(image_bytes, image_content_type, workspace, item_id)
+
+    # Pre-generate enhanced version for faster TSNE processing later
+    enhanced_result = enhance_image_fn(screenshot_url=screenshot_url)
+    if isinstance(enhanced_result, tuple):
+        print('WARNING: failed to enhance image:', enhanced_result[0])
 
     err = update_item(workspace, item_id, item_key, api_key, {'screenshot_url': screenshot_url})
     if err:

--- a/functions/tests/test_enhance_image.py
+++ b/functions/tests/test_enhance_image.py
@@ -90,6 +90,46 @@ class TestEnhancedPath:
         assert _enhanced_path("ws/item/screenshot.jpeg", side=1000) == "ws/item/screenshot.enhanced.jpeg"
 
 
+class TestThumbnailPath:
+    def test_default_size(self):
+        from enhance_image import _thumbnail_path
+
+        assert _thumbnail_path("ws/item/screenshot.jpeg") == "ws/item/screenshot.thumbnail.jpeg"
+
+    def test_custom_size(self):
+        from enhance_image import _thumbnail_path
+
+        assert _thumbnail_path("ws/item/screenshot.jpeg", size=300) == "ws/item/screenshot.thumbnail.300.jpeg"
+
+    def test_size_200_no_extension(self):
+        from enhance_image import _thumbnail_path
+
+        assert _thumbnail_path("ws/item/screenshot.jpeg", size=200) == "ws/item/screenshot.thumbnail.jpeg"
+
+
+class TestCreateThumbnail:
+    def test_respects_max_size(self):
+        from enhance_image import _create_thumbnail
+
+        img = Image.new("RGB", (400, 800), (100, 100, 100))
+        thumb = _create_thumbnail(img, size=200)
+        assert max(thumb.size) == 200
+
+    def test_preserves_aspect_ratio(self):
+        from enhance_image import _create_thumbnail
+
+        img = Image.new("RGB", (400, 200), (100, 100, 100))
+        thumb = _create_thumbnail(img, size=100)
+        assert thumb.size == (100, 50)
+
+    def test_does_not_upscale(self):
+        from enhance_image import _create_thumbnail
+
+        img = Image.new("RGB", (50, 30), (100, 100, 100))
+        thumb = _create_thumbnail(img, size=200)
+        assert thumb.size == (50, 30)
+
+
 class TestEnhance:
     def test_returns_rgb_image(self):
         from enhance_image import enhance
@@ -136,6 +176,13 @@ class TestWhitePatch:
         assert arr.max() == 255
 
 
+def _make_blob(exists=True, public_url="https://example.com/blob"):
+    blob = MagicMock()
+    blob.exists.return_value = exists
+    blob.public_url = public_url
+    return blob
+
+
 class TestEnhanceImage:
     def test_missing_params_returns_400(self):
         from enhance_image import enhance_image
@@ -153,50 +200,64 @@ class TestEnhanceImage:
         assert result[1] == 400
         assert "does not match" in result[0]["error"]
 
-    def test_returns_existing_enhanced(self, mock_storage):
+    def test_returns_existing_enhanced_and_thumbnail(self, mock_storage):
         from enhance_image import enhance_image
 
-        enhanced_blob = MagicMock()
-        enhanced_blob.exists.return_value = True
-        enhanced_blob.public_url = "https://storage.googleapis.com/chronomaps3-eu/ws/item/screenshot.enhanced.jpeg"
-        mock_storage.blob.return_value = enhanced_blob
+        enhanced_blob = _make_blob(exists=True, public_url="https://storage.googleapis.com/chronomaps3-eu/ws/item/screenshot.enhanced.jpeg")
+        thumb_blob = _make_blob(exists=True, public_url="https://storage.googleapis.com/chronomaps3-eu/ws/item/screenshot.thumbnail.jpeg")
+        mock_storage.blob.side_effect = [enhanced_blob, thumb_blob]
 
         result = enhance_image(screenshot_path="ws/item/screenshot.jpeg")
 
         assert not isinstance(result, tuple)
         assert result["already_existed"] is True
         assert result["enhanced_url"] == enhanced_blob.public_url
+        assert result["thumbnail_url"] == thumb_blob.public_url
 
-    def test_enhances_and_uploads_when_not_existing(self, mock_storage):
+    def test_enhances_and_creates_thumbnail_when_not_existing(self, mock_storage):
         from enhance_image import enhance_image
 
         jpeg_bytes = _make_jpeg_bytes()
 
-        enhanced_blob = MagicMock()
-        enhanced_blob.exists.return_value = False
-
-        original_blob = MagicMock()
-        original_blob.exists.return_value = True
+        enhanced_blob = _make_blob(exists=False)
+        original_blob = _make_blob(exists=True)
         original_blob.download_as_bytes.return_value = jpeg_bytes
+        thumb_blob = _make_blob(exists=False)
 
-        # First call to bucket.blob is for enhanced, second for original
-        mock_storage.blob.side_effect = [enhanced_blob, original_blob]
+        mock_storage.blob.side_effect = [enhanced_blob, original_blob, thumb_blob]
 
         result = enhance_image(screenshot_path="ws/item/screenshot.jpeg")
 
         assert not isinstance(result, tuple)
         assert result["already_existed"] is False
         enhanced_blob.upload_from_file.assert_called_once()
-        enhanced_blob.make_public.assert_called_once()
+        thumb_blob.upload_from_file.assert_called_once()
+        assert "thumbnail_url" in result
+        assert "thumbnail_path" in result
+
+    def test_creates_thumbnail_when_enhanced_exists_but_thumbnail_missing(self, mock_storage):
+        from enhance_image import enhance_image
+
+        jpeg_bytes = _make_jpeg_bytes()
+
+        enhanced_blob = _make_blob(exists=True, public_url="https://storage.googleapis.com/chronomaps3-eu/ws/item/screenshot.enhanced.jpeg")
+        enhanced_blob.download_as_bytes.return_value = jpeg_bytes
+        thumb_blob = _make_blob(exists=False)
+
+        mock_storage.blob.side_effect = [enhanced_blob, thumb_blob]
+
+        result = enhance_image(screenshot_path="ws/item/screenshot.jpeg")
+
+        assert result["already_existed"] is True
+        # Should have downloaded enhanced to create thumbnail
+        enhanced_blob.download_as_bytes.assert_called_once()
+        thumb_blob.upload_from_file.assert_called_once()
 
     def test_original_not_found_returns_404(self, mock_storage):
         from enhance_image import enhance_image
 
-        enhanced_blob = MagicMock()
-        enhanced_blob.exists.return_value = False
-
-        original_blob = MagicMock()
-        original_blob.exists.return_value = False
+        enhanced_blob = _make_blob(exists=False)
+        original_blob = _make_blob(exists=False)
 
         mock_storage.blob.side_effect = [enhanced_blob, original_blob]
 
@@ -208,38 +269,51 @@ class TestEnhanceImage:
     def test_with_url_parameter(self, mock_storage):
         from enhance_image import enhance_image
 
-        enhanced_blob = MagicMock()
-        enhanced_blob.exists.return_value = True
-        enhanced_blob.public_url = "https://storage.googleapis.com/chronomaps3-eu/ws/item/screenshot.enhanced.jpeg"
-        mock_storage.blob.return_value = enhanced_blob
+        enhanced_blob = _make_blob(exists=True, public_url="https://storage.googleapis.com/chronomaps3-eu/ws/item/screenshot.enhanced.jpeg")
+        thumb_blob = _make_blob(exists=True, public_url="https://storage.googleapis.com/chronomaps3-eu/ws/item/screenshot.thumbnail.jpeg")
+        mock_storage.blob.side_effect = [enhanced_blob, thumb_blob]
 
         result = enhance_image(screenshot_url="https://storage.googleapis.com/chronomaps3-eu/ws/item/screenshot.jpeg")
 
         assert result["already_existed"] is True
-        mock_storage.blob.assert_called_with("ws/item/screenshot.enhanced.jpeg")
+        blob_calls = [call[0][0] for call in mock_storage.blob.call_args_list]
+        assert "ws/item/screenshot.enhanced.jpeg" in blob_calls
+        assert "ws/item/screenshot.thumbnail.jpeg" in blob_calls
 
     def test_with_custom_side(self, mock_storage):
         from enhance_image import enhance_image
 
-        enhanced_blob = MagicMock()
-        enhanced_blob.exists.return_value = True
-        enhanced_blob.public_url = "https://storage.googleapis.com/chronomaps3-eu/ws/item/screenshot.enhanced.1600.jpeg"
-        mock_storage.blob.return_value = enhanced_blob
+        enhanced_blob = _make_blob(exists=True)
+        thumb_blob = _make_blob(exists=True)
+        mock_storage.blob.side_effect = [enhanced_blob, thumb_blob]
 
         result = enhance_image(screenshot_url="https://storage.googleapis.com/chronomaps3-eu/ws/item/screenshot.jpeg", side=1600)
 
         assert result["already_existed"] is True
-        mock_storage.blob.assert_called_with("ws/item/screenshot.enhanced.1600.jpeg")
+        blob_calls = [call[0][0] for call in mock_storage.blob.call_args_list]
+        assert "ws/item/screenshot.enhanced.1600.jpeg" in blob_calls
+
+    def test_with_custom_thumbnail_size(self, mock_storage):
+        from enhance_image import enhance_image
+
+        enhanced_blob = _make_blob(exists=True)
+        thumb_blob = _make_blob(exists=True)
+        mock_storage.blob.side_effect = [enhanced_blob, thumb_blob]
+
+        result = enhance_image(screenshot_path="ws/item/screenshot.jpeg", thumbnail_size=300)
+
+        blob_calls = [call[0][0] for call in mock_storage.blob.call_args_list]
+        assert "ws/item/screenshot.thumbnail.300.jpeg" in blob_calls
 
     def test_with_legacy_url(self, mock_storage):
         from enhance_image import enhance_image
 
-        enhanced_blob = MagicMock()
-        enhanced_blob.exists.return_value = True
-        enhanced_blob.public_url = "https://storage.googleapis.com/chronomaps3-eu/ws/item/screenshot.enhanced.jpeg"
-        mock_storage.blob.return_value = enhanced_blob
+        enhanced_blob = _make_blob(exists=True)
+        thumb_blob = _make_blob(exists=True)
+        mock_storage.blob.side_effect = [enhanced_blob, thumb_blob]
 
         result = enhance_image(screenshot_url="https://storage.googleapis.com/chronomaps3.firebasestorage.app/ws/item/screenshot.jpeg")
 
         assert result["already_existed"] is True
-        mock_storage.blob.assert_called_with("ws/item/screenshot.enhanced.jpeg")
+        blob_calls = [call[0][0] for call in mock_storage.blob.call_args_list]
+        assert "ws/item/screenshot.enhanced.jpeg" in blob_calls

--- a/functions/tests/test_enhance_image.py
+++ b/functions/tests/test_enhance_image.py
@@ -1,0 +1,245 @@
+"""
+Tests for the enhance_image module.
+
+Covers:
+- URL normalization and validation
+- Enhanced path derivation
+- Enhancement logic (white_patch + stretch_contrast)
+- The enhance_image composite flow (check existing, download, enhance, upload)
+"""
+
+import pytest
+import numpy as np
+from io import BytesIO
+from unittest.mock import MagicMock, patch, PropertyMock
+from PIL import Image
+
+
+@pytest.fixture(autouse=True)
+def mock_storage(monkeypatch):
+    """Mock Firebase Storage bucket used by enhance_image."""
+    mock_bucket = MagicMock()
+    with patch("enhance_image.bucket", mock_bucket):
+        yield mock_bucket
+
+
+def _make_jpeg_bytes(width=100, height=100, color=(128, 100, 80)):
+    """Create valid JPEG bytes for testing."""
+    img = Image.new("RGB", (width, height), color)
+    buff = BytesIO()
+    img.save(buff, format="JPEG")
+    buff.seek(0)
+    return buff.getvalue()
+
+
+class TestNormalizeUrl:
+    def test_normalizes_legacy_url(self):
+        from enhance_image import _normalize_url
+
+        legacy = "https://storage.googleapis.com/chronomaps3.firebasestorage.app/ws/item/screenshot.jpeg"
+        result = _normalize_url(legacy)
+        assert result == "https://storage.googleapis.com/chronomaps3-eu/ws/item/screenshot.jpeg"
+
+    def test_leaves_current_url_unchanged(self):
+        from enhance_image import _normalize_url
+
+        current = "https://storage.googleapis.com/chronomaps3-eu/ws/item/screenshot.jpeg"
+        assert _normalize_url(current) == current
+
+    def test_leaves_unrelated_url_unchanged(self):
+        from enhance_image import _normalize_url
+
+        url = "https://example.com/image.jpeg"
+        assert _normalize_url(url) == url
+
+
+class TestUrlToObjectPath:
+    def test_extracts_path(self):
+        from enhance_image import _url_to_object_path
+
+        url = "https://storage.googleapis.com/chronomaps3-eu/ws/item/screenshot.jpeg"
+        assert _url_to_object_path(url) == "ws/item/screenshot.jpeg"
+
+    def test_normalizes_legacy_url(self):
+        from enhance_image import _url_to_object_path
+
+        url = "https://storage.googleapis.com/chronomaps3.firebasestorage.app/ws/item/screenshot.jpeg"
+        assert _url_to_object_path(url) == "ws/item/screenshot.jpeg"
+
+    def test_rejects_foreign_url(self):
+        from enhance_image import _url_to_object_path
+
+        with pytest.raises(ValueError, match="does not match"):
+            _url_to_object_path("https://example.com/image.jpeg")
+
+
+class TestEnhancedPath:
+    def test_default_side(self):
+        from enhance_image import _enhanced_path
+
+        assert _enhanced_path("ws/item/screenshot.jpeg") == "ws/item/screenshot.enhanced.jpeg"
+
+    def test_custom_side(self):
+        from enhance_image import _enhanced_path
+
+        assert _enhanced_path("ws/item/screenshot.jpeg", side=1600) == "ws/item/screenshot.enhanced.1600.jpeg"
+
+    def test_side_1000_no_extension(self):
+        from enhance_image import _enhanced_path
+
+        assert _enhanced_path("ws/item/screenshot.jpeg", side=1000) == "ws/item/screenshot.enhanced.jpeg"
+
+
+class TestEnhance:
+    def test_returns_rgb_image(self):
+        from enhance_image import enhance
+
+        img = Image.new("RGB", (50, 50), (128, 100, 80))
+        result = enhance(img)
+        assert result.mode == "RGB"
+        assert result.size == (50, 50)
+
+    def test_brightens_dark_image(self):
+        from enhance_image import enhance
+
+        img = Image.new("RGB", (50, 50), (50, 50, 50))
+        result = enhance(img)
+        arr = np.array(result)
+        original_arr = np.array(img)
+        assert arr.mean() > original_arr.mean()
+
+    def test_does_not_crash_on_single_color(self):
+        from enhance_image import enhance
+
+        img = Image.new("RGB", (10, 10), (200, 200, 200))
+        result = enhance(img)
+        assert result.mode == "RGB"
+
+
+class TestWhitePatch:
+    def test_scales_to_white(self):
+        from enhance_image import white_patch
+
+        # Create image with uniform gray pixels
+        img = Image.new("RGB", (50, 50), (100, 100, 100))
+        result = white_patch(img)
+        arr = np.array(result)
+        # All neutral pixels should be scaled to 255
+        assert arr.max() == 255
+
+    def test_handles_already_white(self):
+        from enhance_image import white_patch
+
+        img = Image.new("RGB", (50, 50), (255, 255, 255))
+        result = white_patch(img)
+        arr = np.array(result)
+        assert arr.max() == 255
+
+
+class TestEnhanceImage:
+    def test_missing_params_returns_400(self):
+        from enhance_image import enhance_image
+
+        result = enhance_image()
+        assert isinstance(result, tuple)
+        assert result[1] == 400
+        assert "required" in result[0]["error"]
+
+    def test_invalid_url_returns_400(self):
+        from enhance_image import enhance_image
+
+        result = enhance_image(screenshot_url="https://example.com/bad.jpeg")
+        assert isinstance(result, tuple)
+        assert result[1] == 400
+        assert "does not match" in result[0]["error"]
+
+    def test_returns_existing_enhanced(self, mock_storage):
+        from enhance_image import enhance_image
+
+        enhanced_blob = MagicMock()
+        enhanced_blob.exists.return_value = True
+        enhanced_blob.public_url = "https://storage.googleapis.com/chronomaps3-eu/ws/item/screenshot.enhanced.jpeg"
+        mock_storage.blob.return_value = enhanced_blob
+
+        result = enhance_image(screenshot_path="ws/item/screenshot.jpeg")
+
+        assert not isinstance(result, tuple)
+        assert result["already_existed"] is True
+        assert result["enhanced_url"] == enhanced_blob.public_url
+
+    def test_enhances_and_uploads_when_not_existing(self, mock_storage):
+        from enhance_image import enhance_image
+
+        jpeg_bytes = _make_jpeg_bytes()
+
+        enhanced_blob = MagicMock()
+        enhanced_blob.exists.return_value = False
+
+        original_blob = MagicMock()
+        original_blob.exists.return_value = True
+        original_blob.download_as_bytes.return_value = jpeg_bytes
+
+        # First call to bucket.blob is for enhanced, second for original
+        mock_storage.blob.side_effect = [enhanced_blob, original_blob]
+
+        result = enhance_image(screenshot_path="ws/item/screenshot.jpeg")
+
+        assert not isinstance(result, tuple)
+        assert result["already_existed"] is False
+        enhanced_blob.upload_from_file.assert_called_once()
+        enhanced_blob.make_public.assert_called_once()
+
+    def test_original_not_found_returns_404(self, mock_storage):
+        from enhance_image import enhance_image
+
+        enhanced_blob = MagicMock()
+        enhanced_blob.exists.return_value = False
+
+        original_blob = MagicMock()
+        original_blob.exists.return_value = False
+
+        mock_storage.blob.side_effect = [enhanced_blob, original_blob]
+
+        result = enhance_image(screenshot_path="ws/item/screenshot.jpeg")
+
+        assert isinstance(result, tuple)
+        assert result[1] == 404
+
+    def test_with_url_parameter(self, mock_storage):
+        from enhance_image import enhance_image
+
+        enhanced_blob = MagicMock()
+        enhanced_blob.exists.return_value = True
+        enhanced_blob.public_url = "https://storage.googleapis.com/chronomaps3-eu/ws/item/screenshot.enhanced.jpeg"
+        mock_storage.blob.return_value = enhanced_blob
+
+        result = enhance_image(screenshot_url="https://storage.googleapis.com/chronomaps3-eu/ws/item/screenshot.jpeg")
+
+        assert result["already_existed"] is True
+        mock_storage.blob.assert_called_with("ws/item/screenshot.enhanced.jpeg")
+
+    def test_with_custom_side(self, mock_storage):
+        from enhance_image import enhance_image
+
+        enhanced_blob = MagicMock()
+        enhanced_blob.exists.return_value = True
+        enhanced_blob.public_url = "https://storage.googleapis.com/chronomaps3-eu/ws/item/screenshot.enhanced.1600.jpeg"
+        mock_storage.blob.return_value = enhanced_blob
+
+        result = enhance_image(screenshot_url="https://storage.googleapis.com/chronomaps3-eu/ws/item/screenshot.jpeg", side=1600)
+
+        assert result["already_existed"] is True
+        mock_storage.blob.assert_called_with("ws/item/screenshot.enhanced.1600.jpeg")
+
+    def test_with_legacy_url(self, mock_storage):
+        from enhance_image import enhance_image
+
+        enhanced_blob = MagicMock()
+        enhanced_blob.exists.return_value = True
+        enhanced_blob.public_url = "https://storage.googleapis.com/chronomaps3-eu/ws/item/screenshot.enhanced.jpeg"
+        mock_storage.blob.return_value = enhanced_blob
+
+        result = enhance_image(screenshot_url="https://storage.googleapis.com/chronomaps3.firebasestorage.app/ws/item/screenshot.jpeg")
+
+        assert result["already_existed"] is True
+        mock_storage.blob.assert_called_with("ws/item/screenshot.enhanced.jpeg")

--- a/functions/tests/test_enhance_image.py
+++ b/functions/tests/test_enhance_image.py
@@ -317,3 +317,110 @@ class TestEnhanceImage:
         assert result["already_existed"] is True
         blob_calls = [call[0][0] for call in mock_storage.blob.call_args_list]
         assert "ws/item/screenshot.enhanced.jpeg" in blob_calls
+
+
+class TestOriginalPattern:
+    def test_matches_original_screenshot(self):
+        from enhance_image import _ORIGINAL_PATTERN
+
+        assert _ORIGINAL_PATTERN.match("workspace/item123/screenshot.jpeg")
+
+    def test_rejects_enhanced(self):
+        from enhance_image import _ORIGINAL_PATTERN
+
+        assert not _ORIGINAL_PATTERN.match("workspace/item123/screenshot.enhanced.jpeg")
+        assert not _ORIGINAL_PATTERN.match("workspace/item123/screenshot.enhanced.1600.jpeg")
+
+    def test_rejects_thumbnail(self):
+        from enhance_image import _ORIGINAL_PATTERN
+
+        assert not _ORIGINAL_PATTERN.match("workspace/item123/screenshot.thumbnail.jpeg")
+        assert not _ORIGINAL_PATTERN.match("workspace/item123/screenshot.thumbnail.300.jpeg")
+
+    def test_rejects_tiles(self):
+        from enhance_image import _ORIGINAL_PATTERN
+
+        assert not _ORIGINAL_PATTERN.match("tiles/jma25/0/config.json")
+        assert not _ORIGINAL_PATTERN.match("tiles/jma25/0/8/0/0.png")
+
+    def test_rejects_non_jpeg(self):
+        from enhance_image import _ORIGINAL_PATTERN
+
+        assert not _ORIGINAL_PATTERN.match("workspace/item123/screenshot.png")
+
+    def test_rejects_deeply_nested(self):
+        from enhance_image import _ORIGINAL_PATTERN
+
+        assert not _ORIGINAL_PATTERN.match("a/b/c/screenshot.jpeg")
+
+
+class TestEnhanceAllImages:
+    def test_processes_original_screenshots(self, mock_storage):
+        from enhance_image import enhance_all_images
+
+        jpeg_bytes = _make_jpeg_bytes()
+
+        # Simulate list_blobs returning a mix of originals and non-originals
+        blob1 = MagicMock()
+        blob1.name = "ws1/item1/screenshot.jpeg"
+        blob2 = MagicMock()
+        blob2.name = "ws1/item1/screenshot.enhanced.jpeg"  # should be skipped
+        blob3 = MagicMock()
+        blob3.name = "ws2/item2/screenshot.jpeg"
+        blob4 = MagicMock()
+        blob4.name = "tiles/jma25/config.json"  # should be skipped
+        mock_storage.list_blobs.return_value = [blob1, blob2, blob3, blob4]
+
+        # Mock bucket.blob for enhance_image calls
+        # Each enhance_image call needs: enhanced_blob, original_blob, thumb_blob
+        def make_enhance_blobs():
+            enhanced = _make_blob(exists=False)
+            original = _make_blob(exists=True)
+            original.download_as_bytes.return_value = jpeg_bytes
+            thumb = _make_blob(exists=False)
+            return [enhanced, original, thumb]
+
+        mock_storage.blob.side_effect = make_enhance_blobs() + make_enhance_blobs()
+
+        messages = list(enhance_all_images())
+
+        # Should have processed 2 originals (blob1 and blob3)
+        final = messages[-1]
+        assert final["processed"] == 2
+        assert final["errors"] == 0
+
+    def test_handles_errors_gracefully(self, mock_storage):
+        from enhance_image import enhance_all_images
+
+        blob1 = MagicMock()
+        blob1.name = "ws1/item1/screenshot.jpeg"
+        mock_storage.list_blobs.return_value = [blob1]
+
+        # Make enhance_image fail: enhanced doesn't exist, original doesn't exist
+        enhanced = _make_blob(exists=False)
+        original = _make_blob(exists=False)
+        mock_storage.blob.side_effect = [enhanced, original]
+
+        messages = list(enhance_all_images())
+
+        final = messages[-1]
+        assert final["processed"] == 1
+        assert final["errors"] == 1
+
+    def test_skips_already_enhanced(self, mock_storage):
+        from enhance_image import enhance_all_images
+
+        blob1 = MagicMock()
+        blob1.name = "ws1/item1/screenshot.jpeg"
+        mock_storage.list_blobs.return_value = [blob1]
+
+        # Both enhanced and thumbnail already exist
+        enhanced = _make_blob(exists=True)
+        thumb = _make_blob(exists=True)
+        mock_storage.blob.side_effect = [enhanced, thumb]
+
+        messages = list(enhance_all_images())
+
+        final = messages[-1]
+        assert final["processed"] == 1
+        assert final["enhanced"] == 0

--- a/functions/tests/test_screenshot_handler.py
+++ b/functions/tests/test_screenshot_handler.py
@@ -29,6 +29,18 @@ def mock_storage(monkeypatch):
         yield mock_bucket
 
 
+@pytest.fixture(autouse=True)
+def mock_enhance_image():
+    """Mock enhance_image_fn used by screenshot_handler."""
+    with patch("screenshot_handler.enhance_image_fn") as mock_enhance:
+        mock_enhance.return_value = dict(
+            enhanced_url="https://storage.googleapis.com/chronomaps3-eu/test/screenshot.enhanced.jpeg",
+            enhanced_path="test/screenshot.enhanced.jpeg",
+            already_existed=False,
+        )
+        yield mock_enhance
+
+
 @pytest.fixture
 def mock_openai():
     """Mock the OpenAI client used for image analysis."""
@@ -254,6 +266,20 @@ class TestScreenshotHandler:
         # Should have uploaded image
         mock_storage.blob.assert_called()
 
+    def test_triggers_enhancement(self, mock_openai, mock_api_requests, mock_storage, mock_enhance_image):
+        from screenshot_handler import screenshot_handler
+
+        screenshot_handler(
+            image_bytes=SAMPLE_IMAGE,
+            workspace="ws",
+            api_key="key",
+            image_content_type="image/jpeg",
+        )
+
+        mock_enhance_image.assert_called_once()
+        call_kwargs = mock_enhance_image.call_args[1]
+        assert "screenshot_url" in call_kwargs
+
     def test_returns_error_if_workspace_not_found(self, mock_openai, mock_api_requests, mock_storage):
         from screenshot_handler import screenshot_handler
 
@@ -290,6 +316,22 @@ class TestReplaceItemImage:
         blob.upload_from_string.assert_called_once()
         # Should update the item with the new URL
         mock_api_requests.put.assert_called_once()
+
+    def test_triggers_enhancement(self, mock_api_requests, mock_storage, mock_enhance_image):
+        from screenshot_handler import replace_item_image
+
+        replace_item_image(
+            image_bytes=SAMPLE_IMAGE,
+            image_content_type="image/jpeg",
+            workspace="ws",
+            item_id="item-1",
+            item_key="key-1",
+            api_key="api-key",
+        )
+
+        mock_enhance_image.assert_called_once()
+        call_kwargs = mock_enhance_image.call_args[1]
+        assert "screenshot_url" in call_kwargs
 
     def test_no_analysis_performed(self, mock_api_requests, mock_storage):
         """Verify that no OpenAI calls are made."""


### PR DESCRIPTION
## Summary
- Extracts image enhancement logic (`white_patch`, `stretch_contrast`) from `calc_tsne.py` into a new `enhance_image` module
- Adds a new Cloud Function endpoint (`enhance_image`) that accepts a storage path or full URL, checks if an enhanced version already exists, and enhances + uploads if not
- Validates that full URLs belong to our storage bucket (including legacy URL normalization)
- Refactors `calc_tsne.py` to use the new module instead of inline enhancement, eliminating the `save_image` action pattern
- Adds 22 tests covering URL normalization, path derivation, enhancement logic, and the full API flow

## Test plan
- [x] All 85 tests pass (22 new + 63 existing)
- [ ] Deploy and test with a real screenshot URL
- [ ] Verify `cluster_screenshots` still works end-to-end with the refactored code
- [ ] Test the endpoint with: storage path, full URL, legacy URL, invalid URL, missing image

🤖 Generated with [Claude Code](https://claude.com/claude-code)