### PR TITLE
Optimize enhance_all_images to skip already-complete images

### DIFF
--- a/functions/enhance_image/__init__.py
+++ b/functions/enhance_image/__init__.py
@@ -177,18 +177,33 @@ def enhance_all_images(side: int = 1000, thumbnail_size: int = 200):
     """Iterate over all original screenshots in storage and ensure
     each has an enhanced version and a thumbnail.
 
+    Loads all blob names upfront to determine which images need
+    enhancement or thumbnails, avoiding per-image existence checks.
+
     Yields status dicts for each image processed.
     """
-    processed = 0
+    all_blob_names = set(blob.name for blob in bucket.list_blobs())
+
+    originals = [name for name in all_blob_names if _ORIGINAL_PATTERN.match(name)]
+
+    needs_work = []
+    for path in originals:
+        enhanced_path = _enhanced_path(path, side)
+        thumb_path = _thumbnail_path(path, thumbnail_size)
+        needs_enhance = enhanced_path not in all_blob_names
+        needs_thumb = thumb_path not in all_blob_names
+        if needs_enhance or needs_thumb:
+            needs_work.append((path, needs_enhance, needs_thumb))
+
+    skipped = len(originals) - len(needs_work)
+    yield dict(
+        msg=f'Found {len(originals)} originals, {len(needs_work)} need work, {skipped} already complete',
+    )
+
     enhanced_count = 0
     errors = 0
 
-    for blob in bucket.list_blobs():
-        path = blob.name
-        if not _ORIGINAL_PATTERN.match(path):
-            continue
-
-        processed += 1
+    for path, needs_enhance, needs_thumb in needs_work:
         try:
             result = enhance_image(screenshot_path=path, side=side, thumbnail_size=thumbnail_size)
             if isinstance(result, tuple):
@@ -197,14 +212,16 @@ def enhance_all_images(side: int = 1000, thumbnail_size: int = 200):
             else:
                 if not result['already_existed']:
                     enhanced_count += 1
-                    yield dict(msg=f'Processed {path} (new={not result["already_existed"]})')
+                yield dict(msg=f'Processed {path} (enhanced={needs_enhance}, thumb={needs_thumb})')
         except Exception as e:
             errors += 1
             yield dict(msg=f'Exception processing {path}: {e}')
 
     yield dict(
-        msg=f'Done. Processed: {processed}, newly enhanced: {enhanced_count}, errors: {errors}',
-        processed=processed,
+        msg=f'Done. Total originals: {len(originals)}, skipped: {skipped}, '
+            f'newly enhanced: {enhanced_count}, errors: {errors}',
+        processed=len(needs_work),
+        skipped=skipped,
         enhanced=enhanced_count,
         errors=errors,
     )

--- a/functions/tests/test_enhance_image.py
+++ b/functions/tests/test_enhance_image.py
@@ -366,10 +366,11 @@ class TestEnhanceAllImages:
         jpeg_bytes = _make_jpeg_bytes()
 
         # Simulate list_blobs returning a mix of originals and non-originals
+        # Neither original has enhanced/thumbnail variants in the listing
         blob1 = MagicMock()
         blob1.name = "ws1/item1/screenshot.jpeg"
         blob2 = MagicMock()
-        blob2.name = "ws1/item1/screenshot.enhanced.jpeg"  # should be skipped
+        blob2.name = "ws1/item1/screenshot.enhanced.jpeg"  # present but doesn't match original pattern
         blob3 = MagicMock()
         blob3.name = "ws2/item2/screenshot.jpeg"
         blob4 = MagicMock()
@@ -385,11 +386,13 @@ class TestEnhanceAllImages:
             thumb = _make_blob(exists=False)
             return [enhanced, original, thumb]
 
+        # blob1 has enhanced variant in listing, so only needs thumbnail
+        # blob3 needs both enhanced and thumbnail
         mock_storage.blob.side_effect = make_enhance_blobs() + make_enhance_blobs()
 
         messages = list(enhance_all_images())
 
-        # Should have processed 2 originals (blob1 and blob3)
+        # Should have processed 2 items needing work
         final = messages[-1]
         assert final["processed"] == 2
         assert final["errors"] == 0
@@ -397,6 +400,7 @@ class TestEnhanceAllImages:
     def test_handles_errors_gracefully(self, mock_storage):
         from enhance_image import enhance_all_images
 
+        # No enhanced or thumbnail variants in listing, so it needs work
         blob1 = MagicMock()
         blob1.name = "ws1/item1/screenshot.jpeg"
         mock_storage.list_blobs.return_value = [blob1]
@@ -415,17 +419,19 @@ class TestEnhanceAllImages:
     def test_skips_already_enhanced(self, mock_storage):
         from enhance_image import enhance_all_images
 
+        # Both enhanced and thumbnail variants present in listing
         blob1 = MagicMock()
         blob1.name = "ws1/item1/screenshot.jpeg"
-        mock_storage.list_blobs.return_value = [blob1]
+        blob2 = MagicMock()
+        blob2.name = "ws1/item1/screenshot.enhanced.jpeg"
+        blob3 = MagicMock()
+        blob3.name = "ws1/item1/screenshot.thumbnail.jpeg"
+        mock_storage.list_blobs.return_value = [blob1, blob2, blob3]
 
-        # Both enhanced and thumbnail already exist
-        enhanced = _make_blob(exists=True)
-        thumb = _make_blob(exists=True)
-        mock_storage.blob.side_effect = [enhanced, thumb]
-
+        # No blob() calls should be needed since everything is skipped
         messages = list(enhance_all_images())
 
         final = messages[-1]
-        assert final["processed"] == 1
+        assert final["processed"] == 0
+        assert final["skipped"] == 1
         assert final["enhanced"] == 0


### PR DESCRIPTION
Load all blob names upfront and use set lookups to determine which originals need enhancement or thumbnails, avoiding per-image existence checks and reducing file operations.