### PR TITLE
Add /all-items endpoint for cross-workspace item retrieval

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -227,6 +227,52 @@ DELETE /<workspace>
 
 ---
 
+### All Items (Cross-Workspace)
+
+#### Get All Items
+
+```http
+GET /all-items?page=<int>&page_size=<int>&order_by=<field>&filters=<str>
+```
+
+**Authentication**: Firebase Bearer Token (admin users only)
+
+**Query Parameters**:
+- `page` (default: 0): Page number
+- `page_size` (default: 10): Items per page
+- `order_by` (default: -created_at): Field to sort by (prefix with '-' for descending)
+- `filters` (optional): Pipe-separated filters (same format as `/<workspace>/items`)
+
+**Description**: Retrieves items across all workspaces. Each item includes a `_workspace` field identifying its source workspace. Admin-level access: all private fields are included and no moderation filter is applied. Results are collected from all workspaces, re-sorted, then paginated.
+
+**Example**:
+```bash
+curl "https://region-project.cloudfunctions.net/chronomaps_api/all-items?page=0&page_size=20&order_by=-created_at" \
+  -H "Authorization: Bearer $FIREBASE_TOKEN"
+```
+
+**Response**:
+```json
+[
+  {
+    "_id": "item-id-1",
+    "_workspace": "workspace-id-1",
+    "title": "Item Title",
+    "created_at": "2025-01-15T10:30:00Z",
+    ...
+  },
+  {
+    "_id": "item-id-2",
+    "_workspace": "workspace-id-2",
+    "title": "Another Item",
+    "created_at": "2025-01-14T09:00:00Z",
+    ...
+  }
+]
+```
+
+---
+
 ### Item Management
 
 #### Create Item

--- a/functions/chronomaps_api/__init__.py
+++ b/functions/chronomaps_api/__init__.py
@@ -321,6 +321,44 @@ def create_firestore_index(workspace, order_by_field, filters_str):
         print(f"Error creating index: {e}")
 
 # Endpoints
+@app.get("/all-items")
+@require_firebase_auth
+def get_all_items():
+    page = flask.request.args.get("page", 0, type=int)
+    page_size = flask.request.args.get("page_size", 10, type=int)
+    order_by = flask.request.args.get("order_by")
+    filters = flask.request.args.get("filters", type=str)
+
+    all_items = []
+    for collection in db.collections():
+        config_ref = collection.document('.config')
+        config_doc = config_ref.get()
+        if not config_doc.exists:
+            continue
+
+        workspace = collection.id
+        items, _, _ = fetch_and_filter_items(workspace, filters, order_by)
+
+        items_metadata = [
+            sanitize_metadata(
+                dict(**item.get("metadata", {}), _id=item['id'], _workspace=workspace),
+                exclude_private=False
+            )
+            for item in items
+        ]
+        all_items.extend(items_metadata)
+
+    # Re-sort combined results
+    all_items = sort_items_in_memory(
+        [{"metadata": item} for item in all_items],
+        order_by or "-created_at"
+    )
+    all_items = [item["metadata"] for item in all_items]
+
+    # Paginate
+    paginated = all_items[page * page_size:(page + 1) * page_size]
+    return flask.jsonify(paginated), 200
+
 @app.get("/")
 @require_firebase_auth
 def list_workspaces():

--- a/functions/tests/test_chronomaps_api.py
+++ b/functions/tests/test_chronomaps_api.py
@@ -924,5 +924,164 @@ class TestAggregateEndpoint:
         assert data[1]["count"] == 1
 
 
+class TestAllItemsEndpoint:
+    """Test the /all-items endpoint."""
+
+    def _make_mock_collection(self, workspace_id, items, has_config=True):
+        """Helper to create a mock collection with config and items."""
+        collection = Mock()
+        collection.id = workspace_id
+
+        config_doc = Mock()
+        config_doc.exists = has_config
+
+        config_ref = Mock()
+        config_ref.get.return_value = config_doc
+
+        def mock_document(doc_id):
+            if doc_id == ".config":
+                return config_ref
+            return Mock()
+
+        collection.document.side_effect = mock_document
+        return collection
+
+    def test_get_all_items_basic(self, client, mock_db):
+        """Test basic all-items listing returns items from multiple workspaces."""
+        with patch('chronomaps_api.resolve_firebase_user.get_firebase_user_from_token') as mock_get_user:
+            mock_get_user.return_value = {"email": "admin@example.com", "uid": "admin-uid"}
+
+            # Create mock collections for two workspaces
+            coll1 = self._make_mock_collection("ws1", [])
+            coll2 = self._make_mock_collection("ws2", [])
+
+            mock_db.collections.return_value = [coll1, coll2]
+
+            # Mock fetch_and_filter_items to return items per workspace
+            items_ws1 = [
+                {"id": "item1", "metadata": {"title": "Item 1", "created_at": "2025-01-01"}},
+                {"id": "item2", "metadata": {"title": "Item 2", "created_at": "2025-01-02"}},
+            ]
+            items_ws2 = [
+                {"id": "item3", "metadata": {"title": "Item 3", "created_at": "2025-01-03"}},
+            ]
+
+            def mock_fetch(workspace, filters=None, order_by=None):
+                if workspace == "ws1":
+                    return items_ws1, False, None
+                return items_ws2, False, None
+
+            with patch('chronomaps_api.fetch_and_filter_items', side_effect=mock_fetch):
+                response = client.get(
+                    "/all-items",
+                    headers={"Authorization": "Bearer test-token"}
+                )
+
+            assert response.status_code == 200
+            data = json.loads(response.data)
+            assert len(data) == 3
+            # Each item should have _workspace field
+            workspaces = [item["_workspace"] for item in data]
+            assert "ws1" in workspaces
+            assert "ws2" in workspaces
+
+    def test_get_all_items_pagination(self, client, mock_db):
+        """Test pagination works across workspaces."""
+        with patch('chronomaps_api.resolve_firebase_user.get_firebase_user_from_token') as mock_get_user:
+            mock_get_user.return_value = {"email": "admin@example.com", "uid": "admin-uid"}
+
+            coll1 = self._make_mock_collection("ws1", [])
+            mock_db.collections.return_value = [coll1]
+
+            items_ws1 = [
+                {"id": f"item{i}", "metadata": {"title": f"Item {i}", "created_at": f"2025-01-{i+1:02d}"}}
+                for i in range(5)
+            ]
+
+            def mock_fetch(workspace, filters=None, order_by=None):
+                return items_ws1, False, None
+
+            with patch('chronomaps_api.fetch_and_filter_items', side_effect=mock_fetch):
+                # First page of 2
+                response = client.get(
+                    "/all-items?page=0&page_size=2",
+                    headers={"Authorization": "Bearer test-token"}
+                )
+                assert response.status_code == 200
+                data = json.loads(response.data)
+                assert len(data) == 2
+
+                # Second page of 2
+                response = client.get(
+                    "/all-items?page=1&page_size=2",
+                    headers={"Authorization": "Bearer test-token"}
+                )
+                assert response.status_code == 200
+                data = json.loads(response.data)
+                assert len(data) == 2
+
+                # Third page of 2 (only 1 remaining)
+                response = client.get(
+                    "/all-items?page=2&page_size=2",
+                    headers={"Authorization": "Bearer test-token"}
+                )
+                assert response.status_code == 200
+                data = json.loads(response.data)
+                assert len(data) == 1
+
+    def test_get_all_items_with_filters(self, client, mock_db):
+        """Test filters are passed through to fetch_and_filter_items."""
+        with patch('chronomaps_api.resolve_firebase_user.get_firebase_user_from_token') as mock_get_user:
+            mock_get_user.return_value = {"email": "admin@example.com", "uid": "admin-uid"}
+
+            coll1 = self._make_mock_collection("ws1", [])
+            mock_db.collections.return_value = [coll1]
+
+            captured_filters = []
+
+            def mock_fetch(workspace, filters=None, order_by=None):
+                captured_filters.append(filters)
+                return [], False, None
+
+            with patch('chronomaps_api.fetch_and_filter_items', side_effect=mock_fetch):
+                response = client.get(
+                    '/all-items?filters=metadata.status%20%3D%3D%20"active"',
+                    headers={"Authorization": "Bearer test-token"}
+                )
+
+            assert response.status_code == 200
+            assert len(captured_filters) == 1
+            assert 'metadata.status == "active"' in captured_filters[0]
+
+    def test_get_all_items_requires_auth(self, client, mock_db):
+        """Test that /all-items requires Firebase auth."""
+        response = client.get("/all-items")
+        assert response.status_code == 401
+
+    def test_get_all_items_skips_collections_without_config(self, client, mock_db):
+        """Test that collections without .config are skipped."""
+        with patch('chronomaps_api.resolve_firebase_user.get_firebase_user_from_token') as mock_get_user:
+            mock_get_user.return_value = {"email": "admin@example.com", "uid": "admin-uid"}
+
+            coll_with_config = self._make_mock_collection("ws1", [])
+            coll_without_config = self._make_mock_collection("ws2", [], has_config=False)
+            mock_db.collections.return_value = [coll_with_config, coll_without_config]
+
+            def mock_fetch(workspace, filters=None, order_by=None):
+                return [{"id": "item1", "metadata": {"title": "Item 1", "created_at": "2025-01-01"}}], False, None
+
+            with patch('chronomaps_api.fetch_and_filter_items', side_effect=mock_fetch):
+                response = client.get(
+                    "/all-items",
+                    headers={"Authorization": "Bearer test-token"}
+                )
+
+            assert response.status_code == 200
+            data = json.loads(response.data)
+            # Only items from ws1 (ws2 has no config)
+            assert len(data) == 1
+            assert data[0]["_workspace"] == "ws1"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Add admin-only `GET /all-items` endpoint that aggregates items across all workspaces
- Supports same query params as `/<workspace>/items`: `page`, `page_size`, `order_by`, `filters`
- Each item includes `_workspace` field to identify its source workspace

## Test plan
- [x] 5 new tests added covering basic retrieval, pagination, filters, auth, and config-less collection skipping
- [x] All 42 tests passing locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)