### PR TITLE
Add temporary collaboration for time-limited property editing

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -173,6 +173,9 @@ GET /<workspace>
 
 Note: Full config with keys only returned with admin privilege.
 
+When temporary collaboration is active, the response includes an additional field:
+- `temporary_collaboration_ttl`: Number of seconds remaining until temporary collaboration expires (only present when active)
+
 ---
 
 #### Update Workspace
@@ -207,6 +210,37 @@ PUT /<workspace>?public=<bool>&collaborate=<bool>
   }
 }
 ```
+
+---
+
+#### Set Temporary Collaboration
+
+```http
+POST /<workspace>/temporary-collaboration?time=<int>&properties=<str>
+```
+
+**Authentication**: Admin key required
+
+**Query Parameters**:
+- `time` (required): Time in seconds. When `properties` is provided, this is the duration from now. When `properties` is omitted, this is a delta applied to the existing expiry (e.g. `-60` to subtract a minute).
+- `properties` (optional): Comma-separated list of property names that collaborators may edit without an item key.
+
+**Behavior**:
+- **With `properties`**: Creates or replaces temporary collaboration. Sets expiry to `now + time` and stores the allowed property list.
+- **Without `properties`**: Adjusts the expiry of an existing temporary collaboration by `time` seconds. Returns 400 if no temporary collaboration exists.
+
+**Response**:
+```json
+{
+  "expiry": 1742400000.0,
+  "ttl": 299.5,
+  "allowed_properties": ["title", "description"]
+}
+```
+
+**Effect on other endpoints**:
+- `GET /<workspace>`: Adds `temporary_collaboration_ttl` to the response while active
+- `PUT /<workspace>/<item_id>`: Allows collaborate key holders to update items without an item key, but only for the allowed properties
 
 ---
 
@@ -458,6 +492,8 @@ PUT /<workspace>/<item_id>?item-key=<item_key>
 ```
 
 **Authentication**: Admin key OR Collaborate key + item-key
+
+When [temporary collaboration](#set-temporary-collaboration) is active, a collaborate key may also update items **without** an item key — but only the properties listed in the temporary collaboration configuration. Properties not in the allowed list are silently filtered out. Returns 400 if no allowed properties remain after filtering. Admin and item-key access are unaffected (no property filtering).
 
 **Request Body**:
 ```json
@@ -755,9 +791,15 @@ Stored in Firestore at `<workspace>/.config`
   "config": {
     "collaborate": false,
     "public": false
+  },
+  "temporary_collaboration": {
+    "expiry": 1742400000.0,
+    "allowed_properties": ["title", "description"]
   }
 }
 ```
+
+Note: `temporary_collaboration` is only present when set by an admin via the [Set Temporary Collaboration](#set-temporary-collaboration) endpoint.
 
 **Metadata Fields**:
 - `title`: Workspace display name

--- a/functions/chronomaps_api/__init__.py
+++ b/functions/chronomaps_api/__init__.py
@@ -1,4 +1,5 @@
 import json
+import time
 from firebase_admin import firestore, credentials
 import flask
 import uuid
@@ -50,6 +51,14 @@ def authenticate(workspace, key, required_roles):
 SALT = PRIVATE_KEY[:16].encode()
 def calculate_author_id(email):
     return hashlib.sha256(email.encode() + SALT).hexdigest()
+
+def get_active_temporary_collaboration(workspace):
+    config_ref = db.collection(workspace).document(".config")
+    config = config_ref.get().to_dict()
+    tc = config.get("temporary_collaboration") if config else None
+    if tc and tc["expiry"] > time.time():
+        return tc
+    return None
 
 def sanitize_metadata(metadata, exclude_private=True):
     ret = metadata.copy()
@@ -426,6 +435,11 @@ def get_workspace(workspace):
     ret = config["metadata"]
     if admin:
         ret.update(config["config"])
+    tc = config.get("temporary_collaboration")
+    if tc:
+        ttl = tc["expiry"] - time.time()
+        if ttl > 0:
+            ret["temporary_collaboration_ttl"] = ttl
     return ret, 200
 
 @app.get("/<workspace>/items")
@@ -551,17 +565,29 @@ def get_item(workspace, item_id):
 def update_item(workspace, item_id):
     key = flask.request.headers.get("Authorization")
     item_key = flask.request.args.get("item-key")
+    temp_collab = None
     if not item_key:
-        privilege = authenticate(workspace, key, ["admin"])
+        privilege = authenticate(workspace, key, ["admin", "collaborate"])
+        if privilege < PRIVILEGE_ADMIN:
+            tc = get_active_temporary_collaboration(workspace)
+            if not tc:
+                flask.abort(403, "Unauthorized")
+            temp_collab = tc
     else:
         privilege = authenticate(workspace, key, ["admin", "collaborate"])
     item_ref = db.collection(workspace).document(item_id)
     item = item_ref.get().to_dict()
+    if not item:
+        flask.abort(404, "Item not found")
     if item_key:
-        if not item or item["key"] != item_key:
+        if item["key"] != item_key:
             flask.abort(403, "Unauthorized")
         privilege = PRIVILEGE_PRIVATE_KEY
     metadata = flask.request.json
+    if temp_collab:
+        metadata = {k: v for k, v in metadata.items() if k in temp_collab["allowed_properties"]}
+        if not metadata:
+            flask.abort(400, "No allowed properties in request")
     metadata = sanitize_metadata(metadata, privilege < PRIVILEGE_PRIVATE_KEY)
     item["metadata"].update(metadata)
     item_ref.update({"metadata": item["metadata"]})
@@ -607,6 +633,46 @@ def update_workspace(workspace):
         return {"message": "No updates provided"}, 400
     db.collection(workspace).document(".config").update(updates)
     return {"message": "Workspace updated", "updates": updates}, 200
+
+@app.post("/<workspace>/temporary-collaboration")
+def set_temporary_collaboration(workspace):
+    key = flask.request.headers.get("Authorization")
+    authenticate(workspace, key, ["admin"])
+
+    time_param = flask.request.args.get("time", type=int)
+    properties = flask.request.args.get("properties")
+
+    if time_param is None:
+        flask.abort(400, "Missing required parameter: time")
+
+    config_ref = db.collection(workspace).document(".config")
+
+    if properties:
+        expiry = time.time() + time_param
+        allowed_properties = [p.strip() for p in properties.split(",")]
+        config_ref.update({
+            "temporary_collaboration": {
+                "expiry": expiry,
+                "allowed_properties": allowed_properties
+            }
+        })
+    else:
+        config = config_ref.get().to_dict()
+        existing = config.get("temporary_collaboration") if config else None
+        if not existing:
+            flask.abort(400, "No existing temporary collaboration to adjust")
+        expiry = existing["expiry"] + time_param
+        allowed_properties = existing["allowed_properties"]
+        config_ref.update({
+            "temporary_collaboration.expiry": expiry
+        })
+
+    ttl = expiry - time.time()
+    return {
+        "expiry": expiry,
+        "ttl": ttl,
+        "allowed_properties": allowed_properties
+    }, 200
 
 @app.delete("/<workspace>")
 def delete_workspace(workspace):

--- a/functions/tests/test_chronomaps_api.py
+++ b/functions/tests/test_chronomaps_api.py
@@ -1090,5 +1090,308 @@ class TestAllItemsEndpoint:
             assert data[0]["_workspace"] == "ws1"
 
 
+class TestTemporaryCollaboration:
+    """Test temporary collaboration feature."""
+
+    def _make_config_with_tc(self, sample_workspace_config, expiry_offset=300, properties=None):
+        """Helper: return a config dict with temporary_collaboration set."""
+        import time
+        config = dict(sample_workspace_config)
+        config["temporary_collaboration"] = {
+            "expiry": time.time() + expiry_offset,
+            "allowed_properties": properties or ["title", "description"]
+        }
+        return config
+
+    # --- New endpoint tests ---
+
+    def test_set_temporary_collaboration_with_properties(self, client, mock_db, sample_workspace_config):
+        """Admin sets temporary collaboration with time and properties."""
+        config_ref = Mock()
+        config_ref.get.return_value.to_dict.return_value = sample_workspace_config
+        mock_db.collection.return_value.document.return_value = config_ref
+
+        response = client.post(
+            "/test-workspace/temporary-collaboration?time=300&properties=title,description",
+            headers={"Authorization": sample_workspace_config["keys"]["admin"]}
+        )
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert "expiry" in data
+        assert data["allowed_properties"] == ["title", "description"]
+        assert data["ttl"] > 0
+        config_ref.update.assert_called_once()
+        call_args = config_ref.update.call_args[0][0]
+        assert "temporary_collaboration" in call_args
+        assert call_args["temporary_collaboration"]["allowed_properties"] == ["title", "description"]
+
+    def test_set_temporary_collaboration_adjust_expiry(self, client, mock_db, sample_workspace_config):
+        """Adjust expiry of existing temporary collaboration."""
+        import time as time_mod
+        config_with_tc = self._make_config_with_tc(sample_workspace_config, expiry_offset=300)
+        original_expiry = config_with_tc["temporary_collaboration"]["expiry"]
+
+        config_ref = Mock()
+        config_ref.get.return_value.to_dict.return_value = config_with_tc
+        mock_db.collection.return_value.document.return_value = config_ref
+
+        response = client.post(
+            "/test-workspace/temporary-collaboration?time=60",
+            headers={"Authorization": sample_workspace_config["keys"]["admin"]}
+        )
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert data["expiry"] == original_expiry + 60
+        config_ref.update.assert_called_once_with({"temporary_collaboration.expiry": original_expiry + 60})
+
+    def test_set_temporary_collaboration_subtract_time(self, client, mock_db, sample_workspace_config):
+        """Subtract time from existing temporary collaboration."""
+        config_with_tc = self._make_config_with_tc(sample_workspace_config, expiry_offset=300)
+        original_expiry = config_with_tc["temporary_collaboration"]["expiry"]
+
+        config_ref = Mock()
+        config_ref.get.return_value.to_dict.return_value = config_with_tc
+        mock_db.collection.return_value.document.return_value = config_ref
+
+        response = client.post(
+            "/test-workspace/temporary-collaboration?time=-60",
+            headers={"Authorization": sample_workspace_config["keys"]["admin"]}
+        )
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert data["expiry"] == original_expiry - 60
+
+    def test_set_temporary_collaboration_requires_admin(self, client, mock_db, sample_workspace_config):
+        """Collaborate key should be rejected."""
+        config_ref = Mock()
+        config_ref.get.return_value.to_dict.return_value = sample_workspace_config
+        mock_db.collection.return_value.document.return_value = config_ref
+
+        response = client.post(
+            "/test-workspace/temporary-collaboration?time=300&properties=title",
+            headers={"Authorization": sample_workspace_config["keys"]["collaborate"]}
+        )
+
+        assert response.status_code == 403
+
+    def test_set_temporary_collaboration_adjust_without_existing(self, client, mock_db, sample_workspace_config):
+        """Adjusting without existing temporary collaboration returns 400."""
+        config_ref = Mock()
+        config_ref.get.return_value.to_dict.return_value = sample_workspace_config
+        mock_db.collection.return_value.document.return_value = config_ref
+
+        response = client.post(
+            "/test-workspace/temporary-collaboration?time=60",
+            headers={"Authorization": sample_workspace_config["keys"]["admin"]}
+        )
+
+        assert response.status_code == 400
+
+    def test_set_temporary_collaboration_missing_time(self, client, mock_db, sample_workspace_config):
+        """Missing time parameter returns 400."""
+        config_ref = Mock()
+        config_ref.get.return_value.to_dict.return_value = sample_workspace_config
+        mock_db.collection.return_value.document.return_value = config_ref
+
+        response = client.post(
+            "/test-workspace/temporary-collaboration?properties=title",
+            headers={"Authorization": sample_workspace_config["keys"]["admin"]}
+        )
+
+        assert response.status_code == 400
+
+    # --- get_workspace tests ---
+
+    def test_get_workspace_shows_ttl_when_active(self, client, mock_db, sample_workspace_config):
+        """Workspace metadata includes TTL when temporary collaboration is active."""
+        config_with_tc = self._make_config_with_tc(sample_workspace_config, expiry_offset=300)
+        config_ref = Mock()
+        config_ref.get.return_value.to_dict.return_value = config_with_tc
+        mock_db.collection.return_value.document.return_value = config_ref
+
+        response = client.get(
+            "/test-workspace",
+            headers={"Authorization": sample_workspace_config["keys"]["view"]}
+        )
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert "temporary_collaboration_ttl" in data
+        assert data["temporary_collaboration_ttl"] > 0
+
+    def test_get_workspace_hides_ttl_when_expired(self, client, mock_db, sample_workspace_config):
+        """Workspace metadata excludes TTL when temporary collaboration is expired."""
+        config_with_tc = self._make_config_with_tc(sample_workspace_config, expiry_offset=-100)
+        config_ref = Mock()
+        config_ref.get.return_value.to_dict.return_value = config_with_tc
+        mock_db.collection.return_value.document.return_value = config_ref
+
+        response = client.get(
+            "/test-workspace",
+            headers={"Authorization": sample_workspace_config["keys"]["view"]}
+        )
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert "temporary_collaboration_ttl" not in data
+
+    def test_get_workspace_no_ttl_when_absent(self, client, mock_db, sample_workspace_config):
+        """Workspace metadata has no TTL when no temporary collaboration exists."""
+        config_ref = Mock()
+        config_ref.get.return_value.to_dict.return_value = sample_workspace_config
+        mock_db.collection.return_value.document.return_value = config_ref
+
+        response = client.get(
+            "/test-workspace",
+            headers={"Authorization": sample_workspace_config["keys"]["view"]}
+        )
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert "temporary_collaboration_ttl" not in data
+
+    # --- update_item tests ---
+
+    def test_update_item_temp_collab_filters_properties(self, client, mock_db, sample_workspace_config, sample_item):
+        """Collaborate key without item key: only allowed properties are updated."""
+        config_with_tc = self._make_config_with_tc(sample_workspace_config, properties=["title"])
+
+        config_ref = Mock()
+        config_ref.get.return_value.to_dict.return_value = config_with_tc
+
+        item_ref = Mock()
+        item_ref.get.return_value.to_dict.return_value = sample_item
+
+        def mock_document(doc_id):
+            if doc_id == ".config":
+                return config_ref
+            return item_ref
+
+        mock_db.collection.return_value.document.side_effect = mock_document
+
+        response = client.put(
+            "/test-workspace/test-item-id",
+            json={"title": "New Title", "forbidden_field": "should be filtered"},
+            headers={"Authorization": sample_workspace_config["keys"]["collaborate"]},
+            content_type="application/json"
+        )
+
+        assert response.status_code == 200
+        update_call = item_ref.update.call_args[0][0]
+        assert update_call["metadata"]["title"] == "New Title"
+        assert "forbidden_field" not in update_call["metadata"] or update_call["metadata"].get("forbidden_field") != "should be filtered"
+
+    def test_update_item_temp_collab_rejects_no_allowed_properties(self, client, mock_db, sample_workspace_config, sample_item):
+        """Collaborate key, active temp collab, but no allowed properties in request: 400."""
+        config_with_tc = self._make_config_with_tc(sample_workspace_config, properties=["title"])
+
+        config_ref = Mock()
+        config_ref.get.return_value.to_dict.return_value = config_with_tc
+
+        item_ref = Mock()
+        item_ref.get.return_value.to_dict.return_value = sample_item
+
+        def mock_document(doc_id):
+            if doc_id == ".config":
+                return config_ref
+            return item_ref
+
+        mock_db.collection.return_value.document.side_effect = mock_document
+
+        response = client.put(
+            "/test-workspace/test-item-id",
+            json={"forbidden_field": "not allowed"},
+            headers={"Authorization": sample_workspace_config["keys"]["collaborate"]},
+            content_type="application/json"
+        )
+
+        assert response.status_code == 400
+
+    def test_update_item_temp_collab_rejected_when_expired(self, client, mock_db, sample_workspace_config, sample_item):
+        """Collaborate key, no item key, expired temp collab: 403."""
+        config_with_tc = self._make_config_with_tc(sample_workspace_config, expiry_offset=-100)
+
+        config_ref = Mock()
+        config_ref.get.return_value.to_dict.return_value = config_with_tc
+
+        item_ref = Mock()
+        item_ref.get.return_value.to_dict.return_value = sample_item
+
+        def mock_document(doc_id):
+            if doc_id == ".config":
+                return config_ref
+            return item_ref
+
+        mock_db.collection.return_value.document.side_effect = mock_document
+
+        response = client.put(
+            "/test-workspace/test-item-id",
+            json={"title": "New Title"},
+            headers={"Authorization": sample_workspace_config["keys"]["collaborate"]},
+            content_type="application/json"
+        )
+
+        assert response.status_code == 403
+
+    def test_update_item_admin_unaffected_by_temp_collab(self, client, mock_db, sample_workspace_config, sample_item):
+        """Admin key: all properties pass through regardless of temp collab."""
+        config_with_tc = self._make_config_with_tc(sample_workspace_config, properties=["title"])
+
+        config_ref = Mock()
+        config_ref.get.return_value.to_dict.return_value = config_with_tc
+
+        item_ref = Mock()
+        item_ref.get.return_value.to_dict.return_value = sample_item
+
+        def mock_document(doc_id):
+            if doc_id == ".config":
+                return config_ref
+            return item_ref
+
+        mock_db.collection.return_value.document.side_effect = mock_document
+
+        response = client.put(
+            "/test-workspace/test-item-id",
+            json={"title": "New", "other_field": "also updated"},
+            headers={"Authorization": sample_workspace_config["keys"]["admin"]},
+            content_type="application/json"
+        )
+
+        assert response.status_code == 200
+        update_call = item_ref.update.call_args[0][0]
+        assert update_call["metadata"]["other_field"] == "also updated"
+
+    def test_update_item_with_item_key_unaffected_by_temp_collab(self, client, mock_db, sample_workspace_config, sample_item):
+        """Item key path works as before, no property filtering."""
+        config_with_tc = self._make_config_with_tc(sample_workspace_config, properties=["title"])
+
+        config_ref = Mock()
+        config_ref.get.return_value.to_dict.return_value = config_with_tc
+
+        item_ref = Mock()
+        item_ref.get.return_value.to_dict.return_value = sample_item
+
+        def mock_document(doc_id):
+            if doc_id == ".config":
+                return config_ref
+            return item_ref
+
+        mock_db.collection.return_value.document.side_effect = mock_document
+
+        response = client.put(
+            f"/test-workspace/test-item-id?item-key={sample_item['key']}",
+            json={"title": "New", "other_field": "also updated"},
+            headers={"Authorization": sample_workspace_config["keys"]["collaborate"]},
+            content_type="application/json"
+        )
+
+        assert response.status_code == 200
+        update_call = item_ref.update.call_args[0][0]
+        assert update_call["metadata"]["other_field"] == "also updated"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Adds `POST /<workspace>/temporary-collaboration` endpoint (admin-only) to enable time-limited collaborative editing of specific item properties without requiring per-item keys
- `GET /<workspace>` now includes `temporary_collaboration_ttl` when a temporary collaboration session is active
- `PUT /<workspace>/<item_id>` now allows collaborate key holders to update items without an item key during an active temporary collaboration, filtering to only the allowed properties
- 14 new tests covering the endpoint, TTL visibility, property filtering, expiry handling, and access control
- API docs updated

## Test plan
- [x] All 56 tests pass (42 existing + 14 new)
- [ ] Manual test: set temporary collaboration with `time=300&properties=title,description`
- [ ] Manual test: adjust expiry with `time=-60` (no properties)
- [ ] Manual test: verify `temporary_collaboration_ttl` appears in workspace metadata
- [ ] Manual test: update item with collaborate key (no item key) — only allowed properties accepted
- [ ] Manual test: verify admin and item-key paths are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)