### PR TITLE
Add DELETE endpoint for temporary collaboration

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -244,6 +244,20 @@ POST /<workspace>/temporary-collaboration?time=<int>&properties=<str>
 
 ---
 
+#### Delete Temporary Collaboration
+
+```http
+DELETE /<workspace>/temporary-collaboration
+```
+
+**Authentication**: Admin key required
+
+**Description**: Removes the temporary collaboration configuration from the workspace. This is idempotent — calling it when no temporary collaboration exists does not produce an error.
+
+**Response**: `204 No Content`
+
+---
+
 #### Delete Workspace
 
 ```http
@@ -799,7 +813,7 @@ Stored in Firestore at `<workspace>/.config`
 }
 ```
 
-Note: `temporary_collaboration` is only present when set by an admin via the [Set Temporary Collaboration](#set-temporary-collaboration) endpoint.
+Note: `temporary_collaboration` is only present when set by an admin via the [Set Temporary Collaboration](#set-temporary-collaboration) endpoint. It can be removed via the [Delete Temporary Collaboration](#delete-temporary-collaboration) endpoint.
 
 **Metadata Fields**:
 - `title`: Workspace display name

--- a/functions/chronomaps_api/__init__.py
+++ b/functions/chronomaps_api/__init__.py
@@ -676,6 +676,14 @@ def set_temporary_collaboration(workspace):
         "allowed_properties": allowed_properties
     }, 200
 
+@app.delete("/<workspace>/temporary-collaboration")
+def delete_temporary_collaboration(workspace):
+    key = flask.request.headers.get("Authorization")
+    authenticate(workspace, key, ["admin"])
+    config_ref = db.collection(workspace).document(".config")
+    config_ref.update({"temporary_collaboration": firestore.DELETE_FIELD})
+    return "", 204
+
 @app.delete("/<workspace>")
 def delete_workspace(workspace):
     key = flask.request.headers.get("Authorization")

--- a/functions/tests/test_chronomaps_api.py
+++ b/functions/tests/test_chronomaps_api.py
@@ -14,6 +14,7 @@ import json
 import uuid
 from unittest.mock import Mock, patch, MagicMock
 from flask import Flask
+from firebase_admin import firestore
 import flask
 
 # Import the API module
@@ -1188,6 +1189,48 @@ class TestTemporaryCollaboration:
         )
 
         assert response.status_code == 400
+
+    def test_delete_temporary_collaboration(self, client, mock_db, sample_workspace_config):
+        """Admin can delete temporary collaboration and it no longer appears."""
+        config_with_tc = self._make_config_with_tc(sample_workspace_config)
+        config_ref = Mock()
+        config_ref.get.return_value.to_dict.return_value = config_with_tc
+        mock_db.collection.return_value.document.return_value = config_ref
+
+        response = client.delete(
+            "/test-workspace/temporary-collaboration",
+            headers={"Authorization": sample_workspace_config["keys"]["admin"]}
+        )
+
+        assert response.status_code == 204
+        config_ref.update.assert_called_once_with({"temporary_collaboration": firestore.DELETE_FIELD})
+
+    def test_delete_temporary_collaboration_requires_admin(self, client, mock_db, sample_workspace_config):
+        """Collaborate key should be rejected."""
+        config_ref = Mock()
+        config_ref.get.return_value.to_dict.return_value = sample_workspace_config
+        mock_db.collection.return_value.document.return_value = config_ref
+
+        response = client.delete(
+            "/test-workspace/temporary-collaboration",
+            headers={"Authorization": sample_workspace_config["keys"]["collaborate"]}
+        )
+
+        assert response.status_code == 403
+
+    def test_delete_temporary_collaboration_when_none_exists(self, client, mock_db, sample_workspace_config):
+        """Deleting when no TC exists should still succeed (idempotent)."""
+        config_ref = Mock()
+        config_ref.get.return_value.to_dict.return_value = sample_workspace_config
+        mock_db.collection.return_value.document.return_value = config_ref
+
+        response = client.delete(
+            "/test-workspace/temporary-collaboration",
+            headers={"Authorization": sample_workspace_config["keys"]["admin"]}
+        )
+
+        assert response.status_code == 204
+        config_ref.update.assert_called_once_with({"temporary_collaboration": firestore.DELETE_FIELD})
 
     def test_set_temporary_collaboration_missing_time(self, client, mock_db, sample_workspace_config):
         """Missing time parameter returns 400."""


### PR DESCRIPTION
## Summary
- Adds `DELETE /<workspace>/temporary-collaboration` endpoint to explicitly remove temporary collaboration config from a workspace
- Idempotent — succeeds even when no temporary collaboration exists
- Requires admin authentication, consistent with the POST endpoint
- Includes 3 new tests covering happy path, auth rejection, and idempotent behavior

## Test plan
- [x] All 59 existing tests pass
- [x] New `test_delete_temporary_collaboration` — verifies 204 response and correct Firestore field deletion
- [x] New `test_delete_temporary_collaboration_requires_admin` — verifies 403 for non-admin keys
- [x] New `test_delete_temporary_collaboration_when_none_exists` — verifies idempotent behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)