### PR TITLE
Add updated_at timestamp to item updates

### DIFF
--- a/functions/chronomaps_api/__init__.py
+++ b/functions/chronomaps_api/__init__.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import time
 from firebase_admin import firestore, credentials
@@ -598,6 +599,7 @@ def update_item(workspace, item_id):
             flask.abort(400, "No allowed properties in request")
     metadata = sanitize_metadata(metadata, privilege < PRIVILEGE_PRIVATE_KEY)
     item["metadata"].update(metadata)
+    item["metadata"]["updated_at"] = datetime.datetime.now(datetime.timezone.utc).isoformat()
     item_ref.update({"metadata": item["metadata"]})
     global _all_items_cache
     _all_items_cache = None

--- a/functions/chronomaps_api/__init__.py
+++ b/functions/chronomaps_api/__init__.py
@@ -61,10 +61,12 @@ def get_active_temporary_collaboration(workspace):
         return tc
     return None
 
-def sanitize_metadata(metadata, exclude_private=True):
+def sanitize_metadata(metadata, exclude_private=True, exclude_embedding=False):
     ret = metadata.copy()
     if exclude_private:
         ret = {k: v for k, v in metadata.items() if not (k.startswith(PRIVATE_KEY) or k == 'embedding')}
+    if exclude_embedding:
+        ret = {k: v for k, v in ret.items() if k != 'embedding'}
     if 'author_id' not in metadata and '_private_email' in metadata and metadata['_private_email']:
         ret['author_id'] = calculate_author_id(metadata['_private_email'])
     return ret
@@ -372,7 +374,7 @@ def get_all_items():
             items_metadata = [
                 sanitize_metadata(
                     dict(**item.get("metadata", {}), _id=item['id'], _workspace=workspace, _key=item.get('key', '')),
-                    exclude_private=False
+                    exclude_private=False, exclude_embedding=True
                 )
                 for item in items
             ]
@@ -459,6 +461,7 @@ def get_items(workspace):
     page_size = flask.request.args.get("page_size", 10, type=int)
     order_by = flask.request.args.get("order_by")
     filters = flask.request.args.get("filters", type=str)
+    include_embedding = flask.request.args.get("include_embedding", "false").lower() == "true"
 
     # Add moderation filter for non-admin users
     if privilege < PRIVILEGE_ADMIN:
@@ -475,7 +478,7 @@ def get_items(workspace):
     items_metadata = [
         sanitize_metadata(
             dict(**item.get("metadata", {}), _id=item['id'], **({"_key": item.get("key")} if privilege > PRIVILEGE_PRIVATE_KEY else {})),
-            exclude_private=privilege < PRIVILEGE_PRIVATE_KEY
+            exclude_private=privilege < PRIVILEGE_PRIVATE_KEY, exclude_embedding=not include_embedding
         )
         for item in items
     ]

--- a/functions/cluster_screenshots/calc_tsne.py
+++ b/functions/cluster_screenshots/calc_tsne.py
@@ -39,6 +39,7 @@ def load_records(config, records, params: TSNEParams):
             req_params = dict(page_size=params.TO_PLOT*2, order_by='-created_at')
             yield dict(msg=f'Fetching from {workspace}...')
         workspace_metadata = requests.get(f'{params.CHRONOMAPS_API_URL}/{workspace}', req_params, headers={'Authorization': api_key}).json()
+        req_params['include_embedding'] = 'true'
         items = requests.get(f'{params.CHRONOMAPS_API_URL}/{workspace}/items', req_params, headers={'Authorization': api_key}).json()
         if isinstance(items, list):
             yield dict(msg=f'Got {len(items)} items.')

--- a/functions/screenshot_handler/__init__.py
+++ b/functions/screenshot_handler/__init__.py
@@ -107,9 +107,11 @@ def analyze_image(image_bytes, image_content_type, automatic=False, existing_met
     content = completion.choices[0].message.content
     if not content:
         print('COMPLETION:', completion.choices[0].message.to_dict())
+        now = datetime.datetime.now(datetime.timezone.utc).isoformat()
         return dict(
             content="Couldn't understand anything from the screenshot",
-            created_at=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            created_at=now,
+            updated_at=now,
             automatic=automatic,
         )
 
@@ -130,8 +132,8 @@ def analyze_image(image_bytes, image_content_type, automatic=False, existing_met
         future_scenario_description=content['future_scenario_description'],
         future_scenario_topics=content['future_scenario_topics'],
         detected_language=content['detected_language'],
-        created_at=datetime.datetime.now(datetime.timezone.utc).isoformat(),
-        updated_at=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        created_at=(now := datetime.datetime.now(datetime.timezone.utc).isoformat()),
+        updated_at=now,
         automatic=automatic,
         plausibility=content.get('plausibility'),
         favorable_future=content.get('favorable_future'),

--- a/functions/screenshot_handler/__init__.py
+++ b/functions/screenshot_handler/__init__.py
@@ -131,6 +131,7 @@ def analyze_image(image_bytes, image_content_type, automatic=False, existing_met
         future_scenario_topics=content['future_scenario_topics'],
         detected_language=content['detected_language'],
         created_at=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        updated_at=datetime.datetime.now(datetime.timezone.utc).isoformat(),
         automatic=automatic,
         plausibility=content.get('plausibility'),
         favorable_future=content.get('favorable_future'),

--- a/functions/taxonomy/__init__.py
+++ b/functions/taxonomy/__init__.py
@@ -168,7 +168,8 @@ def _save_topics(records, assignments, version):
         ref = db.collection(workspace).document(item_id)
         batch.update(ref, {
             'metadata.topics': topics,
-            'metadata.topics_version': version
+            'metadata.topics_version': version,
+            'metadata.updated_at': datetime.datetime.now(datetime.timezone.utc).isoformat()
         })
         batch_count += 1
 

--- a/functions/tests/test_chronomaps_api.py
+++ b/functions/tests/test_chronomaps_api.py
@@ -418,6 +418,8 @@ class TestItemEndpoints:
         )
 
         assert response.status_code == 200
+        data = json.loads(response.data)
+        assert "updated_at" in data
 
     def test_delete_item(self, client, mock_db, sample_workspace_config, sample_item):
         """Test deleting an item."""

--- a/functions/tests/test_screenshot_handler.py
+++ b/functions/tests/test_screenshot_handler.py
@@ -107,6 +107,8 @@ class TestAnalyzeImage:
         assert record["transition_bar_certainty"] == 85
         assert record["automatic"] is False
         assert "created_at" in record
+        assert "updated_at" in record
+        assert record["created_at"] == record["updated_at"]
 
     def test_automatic_mode(self, mock_openai):
         from screenshot_handler import analyze_image
@@ -140,6 +142,8 @@ class TestAnalyzeImage:
 
         assert "Couldn't understand" in record["content"]
         assert "created_at" in record
+        assert "updated_at" in record
+        assert record["created_at"] == record["updated_at"]
 
 
 class TestUploadImage:


### PR DESCRIPTION
## Summary
- Adds `updated_at` (ISO UTC timestamp) to item metadata, set automatically on every update path
- Set at item creation time (equal to `created_at`) so the field is always present
- Updated on API PUT endpoint (`update_item`) and taxonomy topic assignment (`_save_topics`)
- Adds `exclude_embedding` parameter to `sanitize_metadata` for fine-grained control over embedding inclusion
- Adds `include_embedding` query parameter to `GET /<workspace>/items` (defaults to `false`), so embeddings are excluded by default to reduce payload size
- Updates `get_all_items` to explicitly exclude embeddings
- Updates TSNE clustering to explicitly request embeddings via `include_embedding=true`

## Test plan
- [x] Create a new item and verify `updated_at` is present and matches `created_at`
- [x] Update an item via PUT endpoint and verify `updated_at` is refreshed
- [x] Verify empty-response fallback path includes `updated_at`
- [x] Run taxonomy assignment and verify `updated_at` is set on affected items
- [ ] Verify `GET /<workspace>/items` excludes embeddings by default
- [ ] Verify `GET /<workspace>/items?include_embedding=true` includes embeddings

🤖 Generated with [Claude Code](https://claude.com/claude-code)