### PR TITLE
Allow clients to pass metadata with screenshot uploads

### DIFF
--- a/functions/main.py
+++ b/functions/main.py
@@ -62,7 +62,11 @@ def screenshot_handler(req: https_fn.Request) -> https_fn.Response:
     print(f"Content type: {content_type}")
     automatic = req.args.get('automatic', 'false').lower() == 'true'
 
-    return screenshot_handler_fn(image_bytes=image_bytes, workspace=workspace, api_key=api_key, automatic=automatic, image_content_type=content_type)
+    # Read optional user-provided metadata from form fields
+    user_metadata_raw = req.form.get('metadata')
+    user_metadata = json.loads(user_metadata_raw) if user_metadata_raw else None
+
+    return screenshot_handler_fn(image_bytes=image_bytes, workspace=workspace, api_key=api_key, automatic=automatic, image_content_type=content_type, user_metadata=user_metadata)
 
 @https_fn.on_request(region='europe-west4', cors=options.CorsOptions(cors_origins="*", cors_methods=["post"]), secrets=['CHRONOMAPS_API_URL'], memory=options.MemoryOption.MB_512)
 def replace_image(req: https_fn.Request) -> https_fn.Response:

--- a/functions/screenshot_handler/__init__.py
+++ b/functions/screenshot_handler/__init__.py
@@ -66,7 +66,7 @@ def get_workspace_moderation(workspace, api_key):
     return moderation or 3, None
 
 
-def analyze_image(image_bytes, image_content_type, automatic=False, existing_metadata=None):
+def analyze_image(image_bytes, image_content_type, automatic=False, existing_metadata=None, user_metadata=None):
     """Run GPT-4 Vision analysis on image bytes.
 
     Args:
@@ -74,6 +74,7 @@ def analyze_image(image_bytes, image_content_type, automatic=False, existing_met
         image_content_type: MIME type of the image.
         automatic: Use automatic analysis prompt.
         existing_metadata: If provided, appended to automatic prompt as context.
+        user_metadata: If provided, user-supplied values to consider in analysis.
 
     Returns an analysis record dict.
     """
@@ -82,6 +83,9 @@ def analyze_image(image_bytes, image_content_type, automatic=False, existing_met
 
     if automatic and existing_metadata:
         prompt = AUTOMATIC_INSTRUCTIONS + "\n\nProvided item metadata - consider it absolute truth:\n" + json.dumps(existing_metadata, indent=2)
+
+    if user_metadata:
+        prompt += "\n\nThe user has provided the following values. Consider them in your analysis and use them to inform your response:\n" + json.dumps(user_metadata, indent=2)
 
     completion = client.chat.completions.create(
         model="gpt-4.1",
@@ -191,9 +195,13 @@ def download_item_image(workspace, item_id):
     return image_bytes, content_type
 
 
-def screenshot_handler(image_bytes, workspace, api_key, automatic=False, image_content_type='image/jpeg'):
+def screenshot_handler(image_bytes, workspace, api_key, automatic=False, image_content_type='image/jpeg', user_metadata=None):
     """Full flow: analyze image, create new item, upload image."""
-    record = analyze_image(image_bytes, image_content_type, automatic=automatic)
+    record = analyze_image(image_bytes, image_content_type, automatic=automatic, user_metadata=user_metadata)
+
+    # Override AI-generated values with user-provided ones so they are preserved
+    if user_metadata:
+        record.update(user_metadata)
 
     moderation_result = get_workspace_moderation(workspace, api_key)
     if isinstance(moderation_result[0], dict) and 'error' in moderation_result[0]:


### PR DESCRIPTION
## Summary
- Clients can now include a JSON `metadata` form field when calling the screenshot handler endpoint
- User-provided values are injected into the AI analysis prompt as context, so the AI considers them during analysis
- After analysis, user-provided values override the AI-generated ones, ensuring they are always preserved in the final item

## Test plan
- [ ] Upload a screenshot without metadata — behavior unchanged
- [ ] Upload a screenshot with `metadata: {"plausibility": 85, "content": "custom text"}` — verify the AI prompt includes the values as context, and the final item preserves the user-provided values
- [ ] Upload with partial metadata (e.g. only `plausibility`) — verify only that field is overridden, rest comes from AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)