### PR TITLE
Fix duplicate delete_temporary_collaboration route

### DIFF
--- a/functions/chronomaps_api/__init__.py
+++ b/functions/chronomaps_api/__init__.py
@@ -614,18 +614,6 @@ def update_item(workspace, item_id):
     _all_items_cache = None
     return item["metadata"], 200
 
-@app.delete("/<workspace>/temporary-collaboration")
-def delete_temporary_collaboration(workspace):
-    key = flask.request.headers.get("Authorization")
-    authenticate(workspace, key, ["admin"])
-    config_ref = db.collection(workspace).document(".config")
-    config = config_ref.get().to_dict()
-    if not config or "temporary_collaboration" not in config:
-        flask.abort(404, "No temporary collaboration to delete")
-    from google.cloud.firestore_v1 import DELETE_FIELD
-    config_ref.update({"temporary_collaboration": DELETE_FIELD})
-    return {"message": "Temporary collaboration deleted"}, 200
-
 @app.delete("/<workspace>/<item_id>")
 def delete_item(workspace, item_id):
     key = flask.request.headers.get("Authorization")


### PR DESCRIPTION
## Summary
- The `delete_temporary_collaboration` route was defined twice in `chronomaps_api/__init__.py`, causing Flask to raise `AssertionError: View function mapping is overwriting an existing endpoint function` on import
- Removed the older duplicate (which had a local import and 404 check), keeping the newer version that uses `firestore.DELETE_FIELD` directly and returns 204

## Test plan
- [ ] CI passes — test collection no longer errors
- [ ] DELETE `/<workspace>/temporary-collaboration` still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)