### PR TITLE
Add multi-database support and db-key auth override

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -15,6 +15,25 @@ Chronomaps Server is a Firebase Cloud Functions-based backend for managing colla
 
 ---
 
+## Multi-Database Support
+
+All endpoints under `chronomaps_api` accept an optional `db` query parameter that selects which Firestore database the request targets:
+
+- `db=<database-id>` — route the request to the named Firestore database.
+- Omitted — route to the project's **default** Firestore database (backwards compatible).
+
+The parameter is honored uniformly across every endpoint (workspace and item CRUD, listings, aggregation, taxonomy, `/all-items`, `/config`, etc.) — individual endpoint sections below do not repeat it.
+
+Example:
+```bash
+curl "https://region-project.cloudfunctions.net/chronomaps_api/?db=staging" \
+  -H "Authorization: Bearer $FIREBASE_TOKEN"
+```
+
+> Only the Flask-based `chronomaps_api` function honors `db`. Auxiliary Cloud Functions (`screenshot_handler`, `complete_flow`, `cluster_screenshots`, `build_taxonomy`, `tag_item`, etc.) always use the default Firestore database.
+
+---
+
 ## Authentication & Authorization
 
 The API uses a multi-tier key-based authorization system.
@@ -45,6 +64,12 @@ Authorization: <api-key>
 ```
 Authorization: Bearer <firebase-token>
 ```
+
+**4. Database Bearer Key** (override for Firebase-auth endpoints)
+```
+Authorization: Bearer <db-key>
+```
+When the target database's `config/config` document defines a `key`, that value can be sent as a bearer token in place of a Firebase ID token on any endpoint that normally requires Firebase auth (`GET /`, `POST /`, `GET /all-items`, `POST /build_taxonomy`). The override is per-database — each db has its own `key`. Configure or rotate it by writing to `config/config` in that db.
 
 ### Workspace Keys
 
@@ -87,6 +112,32 @@ When creating a workspace, you can set a `default_moderation_level` in the works
 ## Core API Endpoints
 
 Base URL: `https://<region>-<project>.cloudfunctions.net/chronomaps_api`
+
+### Database Configuration
+
+#### Get Database Metadata
+
+```http
+GET /config
+```
+
+**Authentication**: None (public endpoint)
+
+**Description**: Returns the `metadata` field of the target database's `config/config` document. Use this to discover human-readable information about a database (title, description, branding, etc.) without authenticating. The response intentionally excludes the `key` and `admins` fields.
+
+**Response**:
+```json
+{
+  "metadata": {
+    "title": "Production Database",
+    "description": "Live chronomaps data"
+  }
+}
+```
+
+If the `config/config` document does not exist, or has no `metadata` field, the endpoint returns `{"metadata": {}}` with status 200.
+
+---
 
 ### Workspace Management
 
@@ -1103,7 +1154,10 @@ Firebase Storage bucket: `chronomaps3-eu`
 
 2. **`emails`** - Email queue for sending emails via Firestore triggers
 
-3. **`config/config`** - Global configuration with admin user list
+3. **`config/config`** - Per-database configuration document. Fields:
+   - `admins` (list of email strings): users allowed to use Firebase auth on this db
+   - `key` (string, optional): bearer-token override for Firebase-auth endpoints (see [Authorization Methods](#authorization-methods))
+   - `metadata` (object, optional): public, human-readable metadata returned by [`GET /config`](#get-database-metadata)
 
 4. **`chronomaps_global`** - Cross-workspace data
    - `taxonomy` document - Hierarchical taxonomy reference (see [Taxonomy Document](#taxonomy-document))
@@ -1228,6 +1282,21 @@ curl "https://region-project.cloudfunctions.net/chronomaps_api/abc123/items?filt
 # Get automatic items that are preferred futures
 curl "https://region-project.cloudfunctions.net/chronomaps_api/abc123/items?filters=automatic==true|favorable_future==prefer" \
   -H "Authorization: KEY123"
+```
+
+### Targeting a Non-Default Database
+
+```bash
+# Read the public metadata for the staging database
+curl "https://region-project.cloudfunctions.net/chronomaps_api/config?db=staging"
+
+# List workspaces in the staging database using a Firebase ID token
+curl "https://region-project.cloudfunctions.net/chronomaps_api/?db=staging" \
+  -H "Authorization: Bearer $FIREBASE_TOKEN"
+
+# List workspaces in the staging database using the per-db bearer key override
+curl "https://region-project.cloudfunctions.net/chronomaps_api/?db=staging" \
+  -H "Authorization: Bearer $STAGING_DB_KEY"
 ```
 
 ### Aggregating Items

--- a/functions/chronomaps_api/__init__.py
+++ b/functions/chronomaps_api/__init__.py
@@ -13,8 +13,13 @@ import re
 from config import PRIVATE_KEY
 from .resolve_firebase_user import require_firebase_auth
 
-db = firestore.client()
 app = flask.Flask(__name__)
+
+
+@app.before_request
+def _resolve_db():
+    db_id = flask.request.args.get('db')
+    flask.g.db = firestore.client(database_id=db_id) if db_id else firestore.client()
 
 # In-memory cache for /all-items
 _all_items_cache = None  # dict with 'params' and 'items', or None
@@ -34,7 +39,7 @@ def generate_keys():
     }
 
 def authenticate(workspace, key, required_roles):
-    config_ref = db.collection(workspace).document(".config")
+    config_ref = flask.g.db.collection(workspace).document(".config")
     config = config_ref.get().to_dict()
     if not config:
         flask.abort(404, "Workspace not found")
@@ -54,7 +59,7 @@ def calculate_author_id(email):
     return hashlib.sha256(email.encode() + SALT).hexdigest()
 
 def get_active_temporary_collaboration(workspace):
-    config_ref = db.collection(workspace).document(".config")
+    config_ref = flask.g.db.collection(workspace).document(".config")
     config = config_ref.get().to_dict()
     tc = config.get("temporary_collaboration") if config else None
     if tc and tc["expiry"] > time.time():
@@ -182,7 +187,7 @@ def sort_items_in_memory(items, order_by_str):
 
     return sorted(items, key=sort_key, reverse=reverse)
 
-def fetch_and_filter_items(workspace, filters=None, order_by=None):
+def fetch_and_filter_items(workspace, filters=None, order_by=None, db_id=None):
     """
     Fetch items from workspace and apply filters/sorting.
 
@@ -195,7 +200,7 @@ def fetch_and_filter_items(workspace, filters=None, order_by=None):
     try:
         # Try using Firestore indexes first
         direction = firestore.Query.ASCENDING
-        items_query = db.collection(workspace)
+        items_query = flask.g.db.collection(workspace)
         order_by_field = order_by
         if order_by_field is None:
             order_by_field = "-created_at"
@@ -230,7 +235,7 @@ def fetch_and_filter_items(workspace, filters=None, order_by=None):
                 index_url = 'https://' + msg.split('https://')[1].split(' ')[0]
 
             # Fetch all items without filtering/ordering
-            items = db.collection(workspace).stream()
+            items = flask.g.db.collection(workspace).stream()
             items = [dict(**doc.to_dict(), id=doc.id) for doc in items]
             items = [item for item in items if item['id'][0] != "."]
 
@@ -243,7 +248,7 @@ def fetch_and_filter_items(workspace, filters=None, order_by=None):
             # Trigger index creation asynchronously
             threading.Thread(
                 target=create_firestore_index,
-                args=(workspace, order_by, filters),
+                args=(workspace, order_by, filters, db_id),
                 daemon=True
             ).start()
         else:
@@ -251,7 +256,7 @@ def fetch_and_filter_items(workspace, filters=None, order_by=None):
 
     return items, use_fallback, index_url
 
-def create_firestore_index(workspace, order_by_field, filters_str):
+def create_firestore_index(workspace, order_by_field, filters_str, database_id=None):
     """
     Create a Firestore index using the Admin API.
     This should be called asynchronously to avoid blocking the request.
@@ -323,7 +328,8 @@ def create_firestore_index(workspace, order_by_field, filters_str):
             "queryScope": "COLLECTION"
         }
 
-        url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/collectionGroups/{workspace}/indexes"
+        db_segment = database_id or '(default)'
+        url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/{db_segment}/collectionGroups/{workspace}/indexes"
         headers = {
             "Authorization": f"Bearer {access_token}",
             "Content-Type": "application/json"
@@ -342,11 +348,18 @@ def create_firestore_index(workspace, order_by_field, filters_str):
 # Endpoints
 @app.get("/taxonomy")
 def get_taxonomy():
-    taxonomy_ref = db.collection('chronomaps_global').document('taxonomy')
+    taxonomy_ref = flask.g.db.collection('chronomaps_global').document('taxonomy')
     taxonomy_doc = taxonomy_ref.get()
     if not taxonomy_doc.exists:
         return flask.jsonify({"error": "Taxonomy not yet generated"}), 404
     return flask.jsonify(taxonomy_doc.to_dict()), 200
+
+@app.get("/config")
+def get_db_config():
+    doc = flask.g.db.collection('config').document('config').get()
+    if not doc.exists:
+        return flask.jsonify({"metadata": {}}), 200
+    return flask.jsonify({"metadata": (doc.to_dict() or {}).get('metadata', {})}), 200
 
 @app.get("/all-items")
 @require_firebase_auth
@@ -356,20 +369,21 @@ def get_all_items():
     page_size = flask.request.args.get("page_size", 10, type=int)
     order_by = flask.request.args.get("order_by")
     filters = flask.request.args.get("filters", type=str)
+    db_id = flask.request.args.get("db")
 
-    cache_params = (order_by, filters)
+    cache_params = (db_id, order_by, filters)
     if _all_items_cache is not None and _all_items_cache['params'] == cache_params:
         all_items = _all_items_cache['items']
     else:
         all_items = []
-        for collection in db.collections():
+        for collection in flask.g.db.collections():
             config_ref = collection.document('.config')
             config_doc = config_ref.get()
             if not config_doc.exists:
                 continue
 
             workspace = collection.id
-            items, _, _ = fetch_and_filter_items(workspace, filters, order_by)
+            items, _, _ = fetch_and_filter_items(workspace, filters, order_by, db_id=db_id)
 
             items_metadata = [
                 sanitize_metadata(
@@ -399,7 +413,7 @@ def get_all_items():
 def list_workspaces():
     configs = []
     print("Listing workspaces for user:", flask.g.firebase_user.get("email"))
-    for collection in db.collections():
+    for collection in flask.g.db.collections():
         ref = collection.document('.config')
         if ref.get().exists:
             config = ref.get().to_dict()
@@ -417,7 +431,7 @@ def create_workspace():
     workspace_id = body.pop("workspace_id", None) or str(uuid.uuid4())
     metadata = body
     # If workspace already exists, return existing config (idempotent)
-    existing = db.collection(workspace_id).document(".config").get()
+    existing = flask.g.db.collection(workspace_id).document(".config").get()
     if existing.exists:
         config = existing.to_dict()
         return {"workspace_id": workspace_id, "config": config}, 200
@@ -427,7 +441,7 @@ def create_workspace():
         "keys": keys,
         "config": {"collaborate": False, "public": False}
     }
-    db.collection(workspace_id).document(".config").set(config)
+    flask.g.db.collection(workspace_id).document(".config").set(config)
     return {"workspace_id": workspace_id, "config": config}, 201
 
 @app.post("/<workspace>")
@@ -439,7 +453,7 @@ def create_item(workspace):
     item_id = str(uuid.uuid4())
     item_key = str(uuid.uuid4())
     item = {"key": item_key, "metadata": metadata}
-    db.collection(workspace).document(item_id).set(item)
+    flask.g.db.collection(workspace).document(item_id).set(item)
     _all_items_cache = None
     return {"item_id": item_id, "item_key": item_key}, 201
 
@@ -447,7 +461,7 @@ def create_item(workspace):
 def get_workspace(workspace):
     key = flask.request.headers.get("Authorization")
     admin = authenticate(workspace, key, ["admin", "collaborate", "view"]) >= PRIVILEGE_ADMIN
-    config_ref = db.collection(workspace).document(".config")
+    config_ref = flask.g.db.collection(workspace).document(".config")
     config = config_ref.get().to_dict()
     ret = config["metadata"]
     if admin:
@@ -478,7 +492,9 @@ def get_items(workspace):
             filters = moderation_filter
 
     # Fetch and filter items
-    items, use_fallback, index_url = fetch_and_filter_items(workspace, filters, order_by)
+    items, use_fallback, index_url = fetch_and_filter_items(
+        workspace, filters, order_by, db_id=flask.request.args.get("db")
+    )
 
     # Sanitize metadata
     items_metadata = [
@@ -522,7 +538,9 @@ def aggregate_items(workspace):
         flask.abort(400, "Missing required parameter: field")
 
     # Fetch and filter items (no ordering needed for aggregation)
-    items, use_fallback, index_url = fetch_and_filter_items(workspace, filters, order_by=None)
+    items, use_fallback, index_url = fetch_and_filter_items(
+        workspace, filters, order_by=None, db_id=flask.request.args.get("db")
+    )
 
     # Count occurrences of each field value
     counts = {}
@@ -569,7 +587,7 @@ def get_item(workspace, item_id):
     key = flask.request.headers.get("Authorization")
     item_key = flask.request.args.get("item-key")
     privilege = authenticate(workspace, key, ["admin", "collaborate", "view"])
-    item_ref = db.collection(workspace).document(item_id)
+    item_ref = flask.g.db.collection(workspace).document(item_id)
     item = item_ref.get().to_dict()
     if not item:
         flask.abort(404, "Item not found")
@@ -593,7 +611,7 @@ def update_item(workspace, item_id):
             temp_collab = tc
     else:
         privilege = authenticate(workspace, key, ["admin", "collaborate"])
-    item_ref = db.collection(workspace).document(item_id)
+    item_ref = flask.g.db.collection(workspace).document(item_id)
     item = item_ref.get().to_dict()
     if not item:
         flask.abort(404, "Item not found")
@@ -622,7 +640,7 @@ def delete_item(workspace, item_id):
         authenticate(workspace, key, ["admin"])
     else:
         authenticate(workspace, key, ["admin", "collaborate"])
-    item_ref = db.collection(workspace).document(item_id)
+    item_ref = flask.g.db.collection(workspace).document(item_id)
     item = item_ref.get().to_dict()
     if not item:
         flask.abort(404, "Item not found")
@@ -652,7 +670,7 @@ def update_workspace(workspace):
         updates["config.collaborate"] = collaborate
     if not updates:
         return {"message": "No updates provided"}, 400
-    db.collection(workspace).document(".config").update(updates)
+    flask.g.db.collection(workspace).document(".config").update(updates)
     return {"message": "Workspace updated", "updates": updates}, 200
 
 @app.post("/<workspace>/temporary-collaboration")
@@ -666,7 +684,7 @@ def set_temporary_collaboration(workspace):
     if time_param is None:
         flask.abort(400, "Missing required parameter: time")
 
-    config_ref = db.collection(workspace).document(".config")
+    config_ref = flask.g.db.collection(workspace).document(".config")
 
     if properties:
         expiry = time.time() + time_param
@@ -701,7 +719,7 @@ def set_temporary_collaboration(workspace):
 def delete_temporary_collaboration(workspace):
     key = flask.request.headers.get("Authorization")
     authenticate(workspace, key, ["admin"])
-    config_ref = db.collection(workspace).document(".config")
+    config_ref = flask.g.db.collection(workspace).document(".config")
     config_ref.update({"temporary_collaboration": firestore.DELETE_FIELD})
     return "", 204
 
@@ -709,7 +727,7 @@ def delete_temporary_collaboration(workspace):
 def delete_workspace(workspace):
     key = flask.request.headers.get("Authorization")
     authenticate(workspace, key, ["admin"])
-    workspace_ref = db.collection(workspace)
+    workspace_ref = flask.g.db.collection(workspace)
     docs = workspace_ref.stream()
     for doc in docs:
         doc.reference.delete()
@@ -719,7 +737,7 @@ def delete_workspace(workspace):
 def delete_items(workspace):
     key = flask.request.headers.get("Authorization")
     authenticate(workspace, key, ["admin"])
-    items_ref = db.collection(workspace)
+    items_ref = flask.g.db.collection(workspace)
     docs = items_ref.stream()
     for doc in docs:
         if doc.id[0] != ".":

--- a/functions/chronomaps_api/resolve_firebase_user.py
+++ b/functions/chronomaps_api/resolve_firebase_user.py
@@ -2,12 +2,20 @@ from typing import Optional
 from functools import wraps
 from flask import request, abort, g
 from firebase_admin.auth import verify_id_token
-from firebase_admin import firestore
 
-db = firestore.client()
+
+def _get_db_config() -> dict:
+    """Return the per-db config/config document as a dict, or {} on miss/error."""
+    try:
+        doc = g.db.collection('config').document('config').get()
+        if doc.exists:
+            return doc.to_dict() or {}
+    except Exception:
+        pass
+    return {}
 
 def get_admins() -> list[str]:
-    return db.collection('config').document('config').get().to_dict().get('admins', [])
+    return _get_db_config().get('admins', [])
 
 def get_token_from_request() -> Optional[str]:
     """Extract the bearer token from the request headers"""
@@ -27,7 +35,7 @@ def get_firebase_user_from_token() -> dict:
         token = get_token_from_request()
         if not token:
             abort(401, description="Not logged in or Invalid credentials")
-        
+
         user = verify_id_token(token)
         assert user is not None
         admins = get_admins()
@@ -39,11 +47,23 @@ def get_firebase_user_from_token() -> dict:
         abort(401, description="Not logged in or Invalid credentials: " + str(e))
 
 def require_firebase_auth(f):
-    """Decorator that requires Firebase authentication for Flask routes"""
+    """Decorator that requires Firebase authentication for Flask routes.
+
+    Accepts either:
+    - A Firebase ID token in `Authorization: Bearer <token>` whose email is in the
+      db's admin list, OR
+    - A bearer token matching the db's `config/config.key` (db-wide override).
+    """
     @wraps(f)
     def decorated_function(*args, **kwargs):
+        token = get_token_from_request()
+        if token:
+            db_key = _get_db_config().get('key')
+            if db_key and token == db_key:
+                g.firebase_user = {'email': 'db-key', 'uid': 'db-key'}
+                return f(*args, **kwargs)
         user = get_firebase_user_from_token()
-        g.firebase_user = user  # Store user in Flask's g object for access in routes
+        g.firebase_user = user
         return f(*args, **kwargs)
     return decorated_function
 

--- a/functions/screenshot_handler/__init__.py
+++ b/functions/screenshot_handler/__init__.py
@@ -12,7 +12,28 @@ import requests
 # Use key, instructions, and filename to generate a structured response from openai api
 INSTRUCTIONS = Path(__file__).with_name('SCREENSHOT_DESCRIBER_PROMPT.md').read_text().strip()
 AUTOMATIC_INSTRUCTIONS = Path(__file__).with_name('AUTOMATIC_SCREENSHOT_DESCRIBER_PROMPT.md').read_text().strip()
-client = OpenAI(api_key=OPENAI_KEY)
+
+
+class _LazyOpenAIClient:
+    """Defers OpenAI() construction until first attribute access.
+
+    Newer openai SDKs raise at construction if no API key is configured, which
+    would break import-time in environments without OPENAI_API_KEY (e.g. CI).
+    Tests can still `patch("screenshot_handler.client", ...)` — patching reads
+    the lazy proxy (no OpenAI construction) and replaces it with the mock.
+    """
+    _real = None
+
+    def _get(self):
+        if self._real is None:
+            self._real = OpenAI(api_key=OPENAI_KEY)
+        return self._real
+
+    def __getattr__(self, name):
+        return getattr(self._get(), name)
+
+
+client = _LazyOpenAIClient()
 
 bucket = storage.bucket(name=BUCKET_NAME)
 

--- a/functions/screenshot_handler/__init__.py
+++ b/functions/screenshot_handler/__init__.py
@@ -30,6 +30,11 @@ class _LazyOpenAIClient:
         return self._real
 
     def __getattr__(self, name):
+        # Don't construct on dunder lookups (e.g. mock.patch probing __func__,
+        # __class__, __signature__). These should miss like they would on a real
+        # OpenAI client rather than eagerly constructing it.
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
         return getattr(self._get(), name)
 
 

--- a/functions/screenshot_handler/__init__.py
+++ b/functions/screenshot_handler/__init__.py
@@ -30,10 +30,11 @@ class _LazyOpenAIClient:
         return self._real
 
     def __getattr__(self, name):
-        # Don't construct on dunder lookups (e.g. mock.patch probing __func__,
-        # __class__, __signature__). These should miss like they would on a real
-        # OpenAI client rather than eagerly constructing it.
-        if name.startswith("__") and name.endswith("__"):
+        # Don't construct on private/dunder lookups (e.g. mock.patch probing
+        # __func__, inspect.iscoroutinefunction probing _is_coroutine_marker).
+        # The real OpenAI public surface we use is all non-underscore (chat,
+        # completions, etc.), so private misses are safe.
+        if name.startswith("_"):
             raise AttributeError(name)
         return getattr(self._get(), name)
 

--- a/functions/tests/conftest.py
+++ b/functions/tests/conftest.py
@@ -69,8 +69,13 @@ def client():
 
 @pytest.fixture
 def mock_db():
-    """Mock Firestore database."""
-    with patch('chronomaps_api.db') as mock:
+    """Mock Firestore database.
+
+    Patches chronomaps_api.firestore.client so that the before_request hook
+    populates flask.g.db with this mock for every test request.
+    """
+    mock = Mock()
+    with patch('chronomaps_api.firestore.client', return_value=mock):
         yield mock
 
 

--- a/functions/tests/test_chronomaps_api.py
+++ b/functions/tests/test_chronomaps_api.py
@@ -19,7 +19,7 @@ import flask
 
 # Import the API module
 from chronomaps_api import (
-    app, db, authenticate, generate_keys, sanitize_metadata,
+    app, authenticate, generate_keys, sanitize_metadata,
     apply_filters_in_memory, sort_items_in_memory, calculate_author_id,
     PRIVILEGE_ADMIN, PRIVILEGE_COLLABORATE, PRIVILEGE_VIEW, PRIVILEGE_PUBLIC,
     PRIVILEGE_PRIVATE_KEY
@@ -171,20 +171,32 @@ class TestFilteringAndSorting:
 class TestAuthentication:
     """Test authentication and authorization."""
 
-    def test_authenticate_admin(self, mock_db, sample_workspace_config):
+    @pytest.fixture
+    def app_ctx_with_db(self, mock_db):
+        """Push a Flask app context and bind mock_db to flask.g.db.
+
+        authenticate() reads flask.g.db (set by the before_request hook in real
+        requests); these unit tests call authenticate() directly and need to
+        bind it manually.
+        """
+        with app.app_context():
+            flask.g.db = mock_db
+            yield mock_db
+
+    def test_authenticate_admin(self, app_ctx_with_db, sample_workspace_config):
         """Test admin authentication."""
         mock_ref = Mock()
         mock_ref.get.return_value.to_dict.return_value = sample_workspace_config
-        mock_db.collection.return_value.document.return_value = mock_ref
+        app_ctx_with_db.collection.return_value.document.return_value = mock_ref
 
         privilege = authenticate("test-workspace", sample_workspace_config["keys"]["admin"], ["admin"])
         assert privilege == PRIVILEGE_ADMIN
 
-    def test_authenticate_collaborate(self, mock_db, sample_workspace_config):
+    def test_authenticate_collaborate(self, app_ctx_with_db, sample_workspace_config):
         """Test collaborate authentication."""
         mock_ref = Mock()
         mock_ref.get.return_value.to_dict.return_value = sample_workspace_config
-        mock_db.collection.return_value.document.return_value = mock_ref
+        app_ctx_with_db.collection.return_value.document.return_value = mock_ref
 
         privilege = authenticate(
             "test-workspace",
@@ -193,11 +205,11 @@ class TestAuthentication:
         )
         assert privilege == PRIVILEGE_COLLABORATE
 
-    def test_authenticate_view(self, mock_db, sample_workspace_config):
+    def test_authenticate_view(self, app_ctx_with_db, sample_workspace_config):
         """Test view authentication."""
         mock_ref = Mock()
         mock_ref.get.return_value.to_dict.return_value = sample_workspace_config
-        mock_db.collection.return_value.document.return_value = mock_ref
+        app_ctx_with_db.collection.return_value.document.return_value = mock_ref
 
         privilege = authenticate(
             "test-workspace",
@@ -206,22 +218,22 @@ class TestAuthentication:
         )
         assert privilege == PRIVILEGE_VIEW
 
-    def test_authenticate_public(self, mock_db, sample_workspace_config):
+    def test_authenticate_public(self, app_ctx_with_db, sample_workspace_config):
         """Test public access."""
         config = sample_workspace_config.copy()
         config["config"]["public"] = True
         mock_ref = Mock()
         mock_ref.get.return_value.to_dict.return_value = config
-        mock_db.collection.return_value.document.return_value = mock_ref
+        app_ctx_with_db.collection.return_value.document.return_value = mock_ref
 
         privilege = authenticate("test-workspace", "invalid-key", ["view"])
         assert privilege == PRIVILEGE_PUBLIC
 
-    def test_authenticate_fails_invalid_key(self, mock_db, sample_workspace_config):
+    def test_authenticate_fails_invalid_key(self, app_ctx_with_db, sample_workspace_config):
         """Test authentication fails with invalid key."""
         mock_ref = Mock()
         mock_ref.get.return_value.to_dict.return_value = sample_workspace_config
-        mock_db.collection.return_value.document.return_value = mock_ref
+        app_ctx_with_db.collection.return_value.document.return_value = mock_ref
 
         with pytest.raises(Exception):  # Flask abort raises werkzeug exception
             authenticate("test-workspace", "invalid-key", ["admin"])
@@ -978,7 +990,7 @@ class TestAllItemsEndpoint:
                 {"id": "item3", "metadata": {"title": "Item 3", "created_at": "2025-01-03"}},
             ]
 
-            def mock_fetch(workspace, filters=None, order_by=None):
+            def mock_fetch(workspace, filters=None, order_by=None, db_id=None):
                 if workspace == "ws1":
                     return items_ws1, False, None
                 return items_ws2, False, None
@@ -1010,7 +1022,7 @@ class TestAllItemsEndpoint:
                 for i in range(5)
             ]
 
-            def mock_fetch(workspace, filters=None, order_by=None):
+            def mock_fetch(workspace, filters=None, order_by=None, db_id=None):
                 return items_ws1, False, None
 
             with patch('chronomaps_api.fetch_and_filter_items', side_effect=mock_fetch):
@@ -1051,7 +1063,7 @@ class TestAllItemsEndpoint:
 
             captured_filters = []
 
-            def mock_fetch(workspace, filters=None, order_by=None):
+            def mock_fetch(workspace, filters=None, order_by=None, db_id=None):
                 captured_filters.append(filters)
                 return [], False, None
 
@@ -1079,7 +1091,7 @@ class TestAllItemsEndpoint:
             coll_without_config = self._make_mock_collection("ws2", [], has_config=False)
             mock_db.collections.return_value = [coll_with_config, coll_without_config]
 
-            def mock_fetch(workspace, filters=None, order_by=None):
+            def mock_fetch(workspace, filters=None, order_by=None, db_id=None):
                 return [{"id": "item1", "metadata": {"title": "Item 1", "created_at": "2025-01-01"}}], False, None
 
             with patch('chronomaps_api.fetch_and_filter_items', side_effect=mock_fetch):
@@ -1437,6 +1449,153 @@ class TestTemporaryCollaboration:
         assert response.status_code == 200
         update_call = item_ref.update.call_args[0][0]
         assert update_call["metadata"]["other_field"] == "also updated"
+
+
+class TestMultiDbRouting:
+    """Test that the `db` query param selects the Firestore database."""
+
+    def test_no_db_param_uses_default_client(self, client):
+        """Absent `db` query param → firestore.client() called with no database_id."""
+        mock = Mock()
+        with patch('chronomaps_api.firestore.client', return_value=mock) as fc:
+            # `/config` is public and only reads the config doc — easy to exercise.
+            mock.collection.return_value.document.return_value.get.return_value.exists = False
+            response = client.get("/config")
+            assert response.status_code == 200
+            # Called with no positional/keyword args (default db).
+            assert fc.call_args.args == ()
+            assert fc.call_args.kwargs == {}
+
+    def test_db_param_passes_database_id(self, client):
+        """`?db=staging` → firestore.client(database_id='staging')."""
+        mock = Mock()
+        with patch('chronomaps_api.firestore.client', return_value=mock) as fc:
+            mock.collection.return_value.document.return_value.get.return_value.exists = False
+            response = client.get("/config?db=staging")
+            assert response.status_code == 200
+            assert fc.call_args.kwargs == {"database_id": "staging"}
+
+
+class TestDbConfigEndpoint:
+    """Test the public GET /config endpoint."""
+
+    def test_returns_metadata_from_config(self, client, mock_db):
+        doc = Mock()
+        doc.exists = True
+        doc.to_dict.return_value = {
+            "key": "secret-db-key",
+            "admins": ["admin@example.com"],
+            "metadata": {"title": "Production DB", "color": "blue"},
+        }
+        mock_db.collection.return_value.document.return_value.get.return_value = doc
+
+        response = client.get("/config")
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        # Only metadata is exposed.
+        assert data == {"metadata": {"title": "Production DB", "color": "blue"}}
+
+    def test_does_not_expose_key_or_admins(self, client, mock_db):
+        doc = Mock()
+        doc.exists = True
+        doc.to_dict.return_value = {
+            "key": "secret-db-key",
+            "admins": ["admin@example.com"],
+            "metadata": {"title": "Some DB"},
+        }
+        mock_db.collection.return_value.document.return_value.get.return_value = doc
+
+        response = client.get("/config")
+        body = response.data.decode()
+        assert "secret-db-key" not in body
+        assert "admin@example.com" not in body
+
+    def test_empty_metadata_when_config_doc_missing(self, client, mock_db):
+        doc = Mock()
+        doc.exists = False
+        mock_db.collection.return_value.document.return_value.get.return_value = doc
+
+        response = client.get("/config")
+        assert response.status_code == 200
+        assert json.loads(response.data) == {"metadata": {}}
+
+    def test_empty_metadata_when_metadata_field_missing(self, client, mock_db):
+        doc = Mock()
+        doc.exists = True
+        doc.to_dict.return_value = {"admins": ["a@b.com"]}
+        mock_db.collection.return_value.document.return_value.get.return_value = doc
+
+        response = client.get("/config")
+        assert response.status_code == 200
+        assert json.loads(response.data) == {"metadata": {}}
+
+    def test_no_auth_required(self, client, mock_db):
+        doc = Mock()
+        doc.exists = False
+        mock_db.collection.return_value.document.return_value.get.return_value = doc
+
+        # No Authorization header at all.
+        response = client.get("/config")
+        assert response.status_code == 200
+
+
+class TestDbKeyAuthOverride:
+    """Test that Authorization: Bearer <db-key> overrides @require_firebase_auth."""
+
+    def test_db_key_grants_access_to_protected_endpoint(self, client, mock_db):
+        """Matching bearer token against config.key bypasses Firebase verification."""
+        cfg_doc = Mock()
+        cfg_doc.exists = True
+        cfg_doc.to_dict.return_value = {"key": "the-db-key", "admins": []}
+        mock_db.collection.return_value.document.return_value.get.return_value = cfg_doc
+        # list_workspaces also iterates db.collections() — return an empty list.
+        mock_db.collections.return_value = []
+
+        # If the override works, verify_id_token must NOT be called.
+        with patch('chronomaps_api.resolve_firebase_user.verify_id_token') as mock_verify:
+            response = client.get(
+                "/",
+                headers={"Authorization": "Bearer the-db-key"},
+            )
+            assert response.status_code == 200
+            mock_verify.assert_not_called()
+
+    def test_wrong_bearer_falls_back_to_firebase_auth(self, client, mock_db):
+        """Non-matching bearer token still attempts Firebase verification and 401s on failure."""
+        cfg_doc = Mock()
+        cfg_doc.exists = True
+        cfg_doc.to_dict.return_value = {"key": "the-db-key", "admins": []}
+        mock_db.collection.return_value.document.return_value.get.return_value = cfg_doc
+
+        with patch(
+            'chronomaps_api.resolve_firebase_user.verify_id_token',
+            side_effect=Exception("invalid token"),
+        ) as mock_verify:
+            response = client.get(
+                "/",
+                headers={"Authorization": "Bearer wrong-token"},
+            )
+            assert response.status_code == 401
+            mock_verify.assert_called_once()
+
+    def test_no_key_field_falls_back_to_firebase_auth(self, client, mock_db):
+        """When config has no `key`, the firebase path runs as today (back-compat)."""
+        cfg_doc = Mock()
+        cfg_doc.exists = True
+        cfg_doc.to_dict.return_value = {"admins": ["admin@example.com"]}
+        mock_db.collection.return_value.document.return_value.get.return_value = cfg_doc
+        mock_db.collections.return_value = []
+
+        with patch(
+            'chronomaps_api.resolve_firebase_user.verify_id_token',
+            return_value={"email": "admin@example.com", "uid": "u1"},
+        ) as mock_verify:
+            response = client.get(
+                "/",
+                headers={"Authorization": "Bearer some-firebase-id-token"},
+            )
+            assert response.status_code == 200
+            mock_verify.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds an optional `db` query parameter to every endpoint in `chronomaps_api` for selecting a non-default Firestore database. Absent param keeps the existing default-db behavior (fully backwards compatible). Resolution is done in a `before_request` hook that populates `flask.g.db`; auxiliary Cloud Functions (`screenshot_handler`, `complete_flow`, etc.) remain pinned to the default database.
- Adds a new public `GET /config` endpoint that returns the target db's `config/config.metadata` (never exposes `key` or `admins`).
- Extends `@require_firebase_auth` so a bearer token matching `config/config.key` on the target db is accepted in place of a Firebase ID token (per-db override). Falls back to the existing Firebase verification when the key is absent or doesn't match.
- Plumbs `db_id` through `fetch_and_filter_items` into the async `create_firestore_index` thread so the Firestore Admin API URL targets the correct database.
- Keys the in-memory `_all_items_cache` on `db_id` so distinct databases don't share cache entries.
- Updates `docs/API.md`: new "Multi-Database Support" section, new auth method, `GET /config` reference, updated `config/config` schema, usage example.

## Test plan
- [x] `pytest functions/tests/` — all 176 tests pass
- [x] Includes new test classes: `TestMultiDbRouting`, `TestDbConfigEndpoint`, `TestDbKeyAuthOverride`
- [ ] Manual smoke (post-deploy): hit `GET /config` with/without `?db=`, hit `GET /` with `Authorization: Bearer <db-key>`, hit `GET /` with no auth and confirm 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)