### PR TITLE
Focus taxonomy & analysis on regional content; bump to gpt-5

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -10,7 +10,7 @@ Chronomaps Server is a Firebase Cloud Functions-based backend for managing colla
 - **Cloud Platform**: Firebase Functions (Google Cloud Functions)
 - **Database**: Firebase Firestore
 - **Storage**: Firebase Storage
-- **AI/ML**: OpenAI GPT-4.1, scikit-learn, NumPy
+- **AI/ML**: OpenAI GPT-5, scikit-learn, NumPy
 - **Deployment Region**: europe-west4
 
 ---
@@ -631,7 +631,7 @@ POST /screenshot_handler?workspace=<id>&api_key=<key>&automatic=<bool>
 
 **Request Body**: Image file
 
-**Description**: Analyzes screenshot using GPT-4.1 Vision model to extract structured information including screenshot type, content, future scenario details, and more. Always creates a new item. After creation, automatically generates the item's semantic embedding and assigns taxonomy topics (if a taxonomy exists). To update an existing item's image or re-analyze it, use the `replace_image` or `reanalyze_item` endpoints instead.
+**Description**: Analyzes screenshot using GPT-5 Vision model to extract structured information including screenshot type, content, future scenario details, and more. Always creates a new item. After creation, automatically generates the item's semantic embedding and assigns taxonomy topics (if a taxonomy exists). To update an existing item's image or re-analyze it, use the `replace_image` or `reanalyze_item` endpoints instead.
 
 **Response**:
 ```json
@@ -706,7 +706,7 @@ POST /reanalyze_item?workspace=<id>&api_key=<key>&item_id=<id>&item_key=<key>&au
 - `item_key` (required): Item key for authorization
 - `automatic` (optional, default: false): Use automatic analysis mode. When true, existing metadata is passed to the AI as context.
 
-**Description**: Re-runs GPT-4.1 Vision analysis on an existing item using its stored image from Firebase Storage. Does not upload a new image. The item's metadata is replaced with new analysis results while preserving the existing `screenshot_url`. After re-analysis, automatically regenerates the item's semantic embedding and re-assigns taxonomy topics. Useful for re-processing items after prompt improvements or when analysis quality needs improvement.
+**Description**: Re-runs GPT-5 Vision analysis on an existing item using its stored image from Firebase Storage. Does not upload a new image. The item's metadata is replaced with new analysis results while preserving the existing `screenshot_url`. After re-analysis, automatically regenerates the item's semantic embedding and re-assigns taxonomy topics. Useful for re-processing items after prompt improvements or when analysis quality needs improvement.
 
 **Response**:
 ```json
@@ -816,7 +816,7 @@ POST /cluster_screenshots?config=<config>&tag=<tag>&no_title=<bool>
 - `tag`: Tag for the cluster set
 - `no_title` (optional): Skip title generation
 
-**Description**: ML-powered screenshot clustering and visualization using t-SNE dimensionality reduction and agglomerative clustering. Generates map tiles (256x256px) for zoom levels and extracts cluster themes using GPT-4.1.
+**Description**: ML-powered screenshot clustering and visualization using t-SNE dimensionality reduction and agglomerative clustering. Generates map tiles (256x256px) for zoom levels and extracts cluster themes using GPT-5.
 
 **Stream Events**:
 ```
@@ -851,9 +851,9 @@ POST /build_taxonomy?similarity_threshold=<float>&max_tags=<int>&redesign=<bool>
 **Query Parameters**:
 - `similarity_threshold` (default: 0.35): Minimum cosine similarity for assigning additional (non-primary) tags to an item
 - `max_tags` (default: 3): Maximum number of topic tags per item
-- `redesign` (default: false): When false, reuses the existing taxonomy and only re-assigns items. When true, samples descriptions and asks GPT-4.1 to refine the taxonomy (keeping existing theme names stable where possible).
+- `redesign` (default: false): When false, reuses the existing taxonomy and only re-assigns items. When true, samples descriptions and asks GPT-5 to refine the taxonomy (keeping existing theme names stable where possible).
 
-**Description**: Builds a cross-workspace hierarchical taxonomy. GPT-4.1 designs the taxonomy top-down from a representative sample of item descriptions, producing mutually exclusive themes and sub-themes with names in four languages (English, Dutch, Hebrew, Arabic). Reference embeddings are generated for each sub-theme definition and cached in Firestore for use by the `tag_item` endpoint.
+**Description**: Builds a cross-workspace hierarchical taxonomy. GPT-5 designs the taxonomy top-down from a representative sample of item descriptions, producing mutually exclusive themes and sub-themes with names in four languages (English, Dutch, Hebrew, Arabic). Reference embeddings are generated for each sub-theme definition and cached in Firestore for use by the `tag_item` endpoint.
 
 Each item receives multi-label topic tags stored in `metadata.topics`. The full taxonomy reference is saved to the `chronomaps_global/taxonomy` Firestore document and can be retrieved via `GET /taxonomy`.
 
@@ -1216,7 +1216,7 @@ All endpoints return appropriate HTTP status codes with error messages:
 
 Required secrets for Firebase Cloud Functions:
 
-- `OPENAI_API_KEY` - OpenAI API key for GPT-4 operations
+- `OPENAI_API_KEY` - OpenAI API key for GPT-5 operations
 - `CHRONOMAPS_API_URL` - Base URL for the Chronomaps API
 - `SERVICE_ACCOUNT_JSON` - Firebase service account credentials
 - `CONFIG__ITS_TIME` - Configuration for scheduled clustering job

--- a/docs/API.md
+++ b/docs/API.md
@@ -10,7 +10,7 @@ Chronomaps Server is a Firebase Cloud Functions-based backend for managing colla
 - **Cloud Platform**: Firebase Functions (Google Cloud Functions)
 - **Database**: Firebase Firestore
 - **Storage**: Firebase Storage
-- **AI/ML**: OpenAI GPT-5, scikit-learn, NumPy
+- **AI/ML**: OpenAI GPT-5.4, scikit-learn, NumPy
 - **Deployment Region**: europe-west4
 
 ---
@@ -631,7 +631,7 @@ POST /screenshot_handler?workspace=<id>&api_key=<key>&automatic=<bool>
 
 **Request Body**: Image file
 
-**Description**: Analyzes screenshot using GPT-5 Vision model to extract structured information including screenshot type, content, future scenario details, and more. Always creates a new item. After creation, automatically generates the item's semantic embedding and assigns taxonomy topics (if a taxonomy exists). To update an existing item's image or re-analyze it, use the `replace_image` or `reanalyze_item` endpoints instead.
+**Description**: Analyzes screenshot using GPT-5.4 Vision model to extract structured information including screenshot type, content, future scenario details, and more. Always creates a new item. After creation, automatically generates the item's semantic embedding and assigns taxonomy topics (if a taxonomy exists). To update an existing item's image or re-analyze it, use the `replace_image` or `reanalyze_item` endpoints instead.
 
 **Response**:
 ```json
@@ -706,7 +706,7 @@ POST /reanalyze_item?workspace=<id>&api_key=<key>&item_id=<id>&item_key=<key>&au
 - `item_key` (required): Item key for authorization
 - `automatic` (optional, default: false): Use automatic analysis mode. When true, existing metadata is passed to the AI as context.
 
-**Description**: Re-runs GPT-5 Vision analysis on an existing item using its stored image from Firebase Storage. Does not upload a new image. The item's metadata is replaced with new analysis results while preserving the existing `screenshot_url`. After re-analysis, automatically regenerates the item's semantic embedding and re-assigns taxonomy topics. Useful for re-processing items after prompt improvements or when analysis quality needs improvement.
+**Description**: Re-runs GPT-5.4 Vision analysis on an existing item using its stored image from Firebase Storage. Does not upload a new image. The item's metadata is replaced with new analysis results while preserving the existing `screenshot_url`. After re-analysis, automatically regenerates the item's semantic embedding and re-assigns taxonomy topics. Useful for re-processing items after prompt improvements or when analysis quality needs improvement.
 
 **Response**:
 ```json
@@ -816,7 +816,7 @@ POST /cluster_screenshots?config=<config>&tag=<tag>&no_title=<bool>
 - `tag`: Tag for the cluster set
 - `no_title` (optional): Skip title generation
 
-**Description**: ML-powered screenshot clustering and visualization using t-SNE dimensionality reduction and agglomerative clustering. Generates map tiles (256x256px) for zoom levels and extracts cluster themes using GPT-5.
+**Description**: ML-powered screenshot clustering and visualization using t-SNE dimensionality reduction and agglomerative clustering. Generates map tiles (256x256px) for zoom levels and extracts cluster themes using GPT-5.4.
 
 **Stream Events**:
 ```
@@ -851,9 +851,9 @@ POST /build_taxonomy?similarity_threshold=<float>&max_tags=<int>&redesign=<bool>
 **Query Parameters**:
 - `similarity_threshold` (default: 0.35): Minimum cosine similarity for assigning additional (non-primary) tags to an item
 - `max_tags` (default: 3): Maximum number of topic tags per item
-- `redesign` (default: false): When false, reuses the existing taxonomy and only re-assigns items. When true, samples descriptions and asks GPT-5 to refine the taxonomy (keeping existing theme names stable where possible).
+- `redesign` (default: false): When false, reuses the existing taxonomy and only re-assigns items. When true, samples descriptions and asks GPT-5.4 to refine the taxonomy (keeping existing theme names stable where possible).
 
-**Description**: Builds a cross-workspace hierarchical taxonomy. GPT-5 designs the taxonomy top-down from a representative sample of item descriptions, producing mutually exclusive themes and sub-themes with names in four languages (English, Dutch, Hebrew, Arabic). Reference embeddings are generated for each sub-theme definition and cached in Firestore for use by the `tag_item` endpoint.
+**Description**: Builds a cross-workspace hierarchical taxonomy. GPT-5.4 designs the taxonomy top-down from a representative sample of item descriptions, producing mutually exclusive themes and sub-themes with names in four languages (English, Dutch, Hebrew, Arabic). Reference embeddings are generated for each sub-theme definition and cached in Firestore for use by the `tag_item` endpoint.
 
 Each item receives multi-label topic tags stored in `metadata.topics`. The full taxonomy reference is saved to the `chronomaps_global/taxonomy` Firestore document and can be retrieved via `GET /taxonomy`.
 
@@ -1216,7 +1216,7 @@ All endpoints return appropriate HTTP status codes with error messages:
 
 Required secrets for Firebase Cloud Functions:
 
-- `OPENAI_API_KEY` - OpenAI API key for GPT-5 operations
+- `OPENAI_API_KEY` - OpenAI API key for GPT-5.4 operations
 - `CHRONOMAPS_API_URL` - Base URL for the Chronomaps API
 - `SERVICE_ACCOUNT_JSON` - Firebase service account credentials
 - `CONFIG__ITS_TIME` - Configuration for scheduled clustering job

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ This directory contains comprehensive documentation for the Chronomaps Server AP
 
 ## Overview
 
-Chronomaps Server is a Firebase Cloud Functions-based backend for managing collaborative workspaces that collect and process future scenario screenshots. The system uses AI-powered analysis (GPT-4.1 Vision) to extract structured information from screenshots and provides ML-based clustering and visualization capabilities.
+Chronomaps Server is a Firebase Cloud Functions-based backend for managing collaborative workspaces that collect and process future scenario screenshots. The system uses AI-powered analysis (GPT-5 Vision) to extract structured information from screenshots and provides ML-based clustering and visualization capabilities.
 
 ## Quick Start
 
@@ -21,7 +21,7 @@ Chronomaps Server is a Firebase Cloud Functions-based backend for managing colla
 
 - Multi-tenant workspace architecture
 - Fine-grained access control (5-level privilege system)
-- AI-powered screenshot analysis using GPT-4.1 Vision
+- AI-powered screenshot analysis using GPT-5 Vision
 - Modular image operations (replace image, re-analyze item)
 - Interactive chat agent for guided item completion
 - ML clustering (t-SNE + Agglomerative Clustering)
@@ -33,7 +33,7 @@ Chronomaps Server is a Firebase Cloud Functions-based backend for managing colla
 
 - Python 3.12 + Flask
 - Firebase (Functions, Firestore, Storage, Auth)
-- OpenAI GPT-4.1
+- OpenAI GPT-5
 - scikit-learn for ML clustering
 
 ## Documentation Structure

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ This directory contains comprehensive documentation for the Chronomaps Server AP
 
 ## Overview
 
-Chronomaps Server is a Firebase Cloud Functions-based backend for managing collaborative workspaces that collect and process future scenario screenshots. The system uses AI-powered analysis (GPT-5 Vision) to extract structured information from screenshots and provides ML-based clustering and visualization capabilities.
+Chronomaps Server is a Firebase Cloud Functions-based backend for managing collaborative workspaces that collect and process future scenario screenshots. The system uses AI-powered analysis (GPT-5.4 Vision) to extract structured information from screenshots and provides ML-based clustering and visualization capabilities.
 
 ## Quick Start
 
@@ -21,7 +21,7 @@ Chronomaps Server is a Firebase Cloud Functions-based backend for managing colla
 
 - Multi-tenant workspace architecture
 - Fine-grained access control (5-level privilege system)
-- AI-powered screenshot analysis using GPT-5 Vision
+- AI-powered screenshot analysis using GPT-5.4 Vision
 - Modular image operations (replace image, re-analyze item)
 - Interactive chat agent for guided item completion
 - ML clustering (t-SNE + Agglomerative Clustering)
@@ -33,7 +33,7 @@ Chronomaps Server is a Firebase Cloud Functions-based backend for managing colla
 
 - Python 3.12 + Flask
 - Firebase (Functions, Firestore, Storage, Auth)
-- OpenAI GPT-5
+- OpenAI GPT-5.4
 - scikit-learn for ML clustering
 
 ## Documentation Structure

--- a/functions/TEST_SUITE_README.md
+++ b/functions/TEST_SUITE_README.md
@@ -192,7 +192,7 @@ A comprehensive test suite covering all API endpoints and functionality.
 **Test Classes (test_screenshot_handler.py):**
 
 9. **TestAnalyzeImage** (4 tests)
-   - Returns analysis record from GPT-4 Vision
+   - Returns analysis record from GPT-5 Vision
    - Automatic mode
    - Automatic mode with existing metadata context
    - Handles empty GPT response

--- a/functions/TEST_SUITE_README.md
+++ b/functions/TEST_SUITE_README.md
@@ -192,7 +192,7 @@ A comprehensive test suite covering all API endpoints and functionality.
 **Test Classes (test_screenshot_handler.py):**
 
 9. **TestAnalyzeImage** (4 tests)
-   - Returns analysis record from GPT-5 Vision
+   - Returns analysis record from GPT-5.4 Vision
    - Automatic mode
    - Automatic mode with existing metadata context
    - Handles empty GPT response

--- a/functions/cluster_screenshots/__init__.py
+++ b/functions/cluster_screenshots/__init__.py
@@ -91,7 +91,7 @@ def extract_cluster_title(client, taglines, previous=None):
     prompt = EXTRACT_TITLE_INSTRUCTIONS.replace(':TAGLINES:', taglines).replace(':PREVIOUS:', previous)
 
     completion = client.chat.completions.create(
-        model="gpt-4.1",
+        model="gpt-5",
         messages=[
             {
                 "role": "user",

--- a/functions/cluster_screenshots/__init__.py
+++ b/functions/cluster_screenshots/__init__.py
@@ -91,7 +91,7 @@ def extract_cluster_title(client, taglines, previous=None):
     prompt = EXTRACT_TITLE_INSTRUCTIONS.replace(':TAGLINES:', taglines).replace(':PREVIOUS:', previous)
 
     completion = client.chat.completions.create(
-        model="gpt-5",
+        model="gpt-5.4",
         messages=[
             {
                 "role": "user",
@@ -100,7 +100,6 @@ def extract_cluster_title(client, taglines, previous=None):
                 ],
             }
         ],
-        temperature=0.5,
         response_format={
             "type": 'json_object'
         }

--- a/functions/item_ingress_agent/__init__.py
+++ b/functions/item_ingress_agent/__init__.py
@@ -51,7 +51,7 @@ def get_assistant_id(client, workspace, workspace_metadata):
     if _assistant_id is None:
         _assistant_id = client.beta.assistants.create(
             name=agent_name,
-            model="gpt-5",
+            model="gpt-4.1",
             description="Chronomaps Item Ingress Agent",
             instructions=instructions,
             tools=TOOLS,

--- a/functions/item_ingress_agent/__init__.py
+++ b/functions/item_ingress_agent/__init__.py
@@ -51,7 +51,7 @@ def get_assistant_id(client, workspace, workspace_metadata):
     if _assistant_id is None:
         _assistant_id = client.beta.assistants.create(
             name=agent_name,
-            model="gpt-4.1",
+            model="gpt-5",
             description="Chronomaps Item Ingress Agent",
             instructions=instructions,
             tools=TOOLS,

--- a/functions/screenshot_handler/AUTOMATIC_SCREENSHOT_DESCRIBER_PROMPT.md
+++ b/functions/screenshot_handler/AUTOMATIC_SCREENSHOT_DESCRIBER_PROMPT.md
@@ -52,8 +52,22 @@ The `content` field should include specific details about the screenshot's conte
 - For a **sign in a demonstration**, describe the text and imagery on the sign, including any symbols or graphics.
 
 After reading all the data, try to capture the essence of the future that the participant is envisioning, and in which this screenshot is set.
-Describe this speculative future in a few sentences, focusing on the key themes, technologies, or societal changes that are implied by the content of the screenshot.
-This description should describe the future scenario, without referencing the specific content of the screenshot. 
+Describe this speculative future in a few sentences, focusing on the key themes, anxieties, hopes, or societal changes that are implied by the content of the screenshot.
+This description should describe the future scenario, without referencing the specific content of the screenshot.
+
+### Content-over-template guidance for the `future_scenario_*` fields and `content_title`
+
+The template (social media post, AI agent query, notification, review, sign, etc.) is just the **wrapper** the participant chose to express their idea. The summary, tagline, description, and topics must describe what the scenario is **about** — the substantive concern the participant is voicing — **not** the medium they used to voice it.
+
+- If someone asks an AI assistant "How do I get my son out of military service?", the scenario is about military service / conscientious objection / state coercion, **not** about AI. Mention AI only if the *role of the AI itself* is the substantive concern (e.g., AI replacing rabbinic authority, AI deciding immigration cases, AI deepfakes destroying trust).
+- If someone posts on social media about a checkpoint, the scenario is about checkpoints and freedom of movement, **not** about social media.
+- If a notification announces a ceasefire, the scenario is about the ceasefire and what it changes, **not** about notification systems.
+- A review of a peace-process app is about whatever the app is doing in the imagined future (e.g., reconciliation infrastructure), **not** about apps or reviews.
+
+When choosing `future_scenario_topics`, prefer specific, content-grounded topics ("checkpoint freedom of movement", "Jewish-diaspora-Israel ties", "settler violence", "religion and the state", "climate displacement", "right of return") over generic placeholders like "AI", "social media", "technology", "politics", or "society" — unless one of those generic terms is genuinely the substance of the scenario.
+
+The Israeli-Palestinian region, Israeli politics and society, and Jewish identity are recurring substantive concerns in this dataset; when they are present in the content, surface them specifically rather than abstracting them away.
+
 The summary and analysis should be returned in the JSON format specified above, under the `future_scenario*` fields.
 
 Here's the file for your analysis - remember to reply only the JSON object only, without any additional text, explanation or embellishments.

--- a/functions/screenshot_handler/SCREENSHOT_DESCRIBER_PROMPT.md
+++ b/functions/screenshot_handler/SCREENSHOT_DESCRIBER_PROMPT.md
@@ -50,8 +50,22 @@ The `content` field should include specific details about the screenshot's conte
 - For a **sign in a demonstration**, describe the text and imagery on the sign, including any symbols or graphics.
 
 After reading all the data, try to capture the essence of the future that the participant is envisioning, and in which this screenshot is set.
-Describe this speculative future in a few sentences, focusing on the key themes, technologies, or societal changes that are implied by the content of the screenshot.
-This description should describe the future scenario, without referencing the specific content of the screenshot. 
+Describe this speculative future in a few sentences, focusing on the key themes, anxieties, hopes, or societal changes that are implied by the content of the screenshot.
+This description should describe the future scenario, without referencing the specific content of the screenshot.
+
+### Content-over-template guidance for the `future_scenario_*` fields and `content_title`
+
+The template (social media post, AI agent query, notification, review, sign, etc.) is just the **wrapper** the participant chose to express their idea. The summary, tagline, description, and topics must describe what the scenario is **about** — the substantive concern the participant is voicing — **not** the medium they used to voice it.
+
+- If someone asks an AI assistant "How do I get my son out of military service?", the scenario is about military service / conscientious objection / state coercion, **not** about AI. Mention AI only if the *role of the AI itself* is the substantive concern (e.g., AI replacing rabbinic authority, AI deciding immigration cases, AI deepfakes destroying trust).
+- If someone posts on social media about a checkpoint, the scenario is about checkpoints and freedom of movement, **not** about social media.
+- If a notification announces a ceasefire, the scenario is about the ceasefire and what it changes, **not** about notification systems.
+- A review of a peace-process app is about whatever the app is doing in the imagined future (e.g., reconciliation infrastructure), **not** about apps or reviews.
+
+When choosing `future_scenario_topics`, prefer specific, content-grounded topics ("checkpoint freedom of movement", "Jewish-diaspora-Israel ties", "settler violence", "religion and the state", "climate displacement", "right of return") over generic placeholders like "AI", "social media", "technology", "politics", or "society" — unless one of those generic terms is genuinely the substance of the scenario.
+
+The Israeli-Palestinian region, Israeli politics and society, and Jewish identity are recurring substantive concerns in this dataset; when they are present in the content, surface them specifically rather than abstracting them away.
+
 The summary and analysis should be returned in the JSON format specified above, under the `future_scenario*` fields.
 
 Here's the file for your analysis - remember to reply only the JSON object only, without any additional text, explanation or embellishments.

--- a/functions/screenshot_handler/__init__.py
+++ b/functions/screenshot_handler/__init__.py
@@ -120,7 +120,7 @@ Consider them as truth (overriding any text you might extract from the image), u
  """ + json.dumps(user_metadata, indent=2)
 
     completion = client.chat.completions.create(
-        model="gpt-4.1",
+        model="gpt-5",
         messages=[
             {
                 "role": "user",

--- a/functions/screenshot_handler/__init__.py
+++ b/functions/screenshot_handler/__init__.py
@@ -120,7 +120,7 @@ Consider them as truth (overriding any text you might extract from the image), u
  """ + json.dumps(user_metadata, indent=2)
 
     completion = client.chat.completions.create(
-        model="gpt-5",
+        model="gpt-5.4",
         messages=[
             {
                 "role": "user",

--- a/functions/taxonomy/DESIGN_TAXONOMY_PROMPT.md
+++ b/functions/taxonomy/DESIGN_TAXONOMY_PROMPT.md
@@ -1,17 +1,27 @@
-You are a taxonomy designer. You are given a sample of "future scenario descriptions" — each one describes a speculative future scenario imagined by workshop participants. The scenarios span many topics: politics, technology, climate, society, conflict, and more.
+You are a taxonomy designer. You are given a sample of "future scenario descriptions" — each one describes a speculative future scenario imagined by workshop participants. The workshops are situated in the context of the Israeli-Palestinian region: most participants are Israelis, Palestinians, and people closely connected to the region or to Jewish life elsewhere, and their scenarios most often engage with the political, social, religious, and human realities of that context. Other scenarios touch on broader concerns (climate, technology, work, family life) that may not be region-specific.
 
-Your task: Design a two-level hierarchical taxonomy that can categorize ALL of these scenarios (and similar ones not shown here) into clear, useful categories.
+Your task: Design a two-level hierarchical taxonomy that captures the actual substance of these scenarios — what people are imagining, fearing, hoping for, or grappling with — and that lets a future scenario be placed in a clearly relevant category.
 
-## Requirements
+## Editorial direction
+
+The taxonomy must feel topical and grounded in the content, not bland or template-driven. Concretely:
+
+- **Prioritize regional and identity themes.** The dominant subject matter is expected to be the Israeli-Palestinian conflict and its aftermath, Israeli politics and society, Palestinian politics and society, Jewish identity (religious, secular, diasporic), and the relationships between these. Themes and sub-themes in these areas should be the most specific and the most numerous, *to the extent that the sample supports them*. Look at the sample to decide how much weight each deserves — do not pad with regional themes that have no matching scenarios, and do not flatten regional richness into one generic "Politics" bucket.
+- **Be specific where the content is specific.** Prefer sub-themes like "Checkpoints and freedom of movement", "Settler violence and rule of law", "Religion and the state", "Military service and conscientious objection", "Diaspora–Israel relations", "Hebrew/Arabic language politics", "Right of return and demography", "Two-state / one-state / confederation futures", "Memory, trauma, and reconciliation" — over vague labels like "Politics", "Religion", or "Society". The exact set should come from what you actually see in the sample.
+- **Keep generic themes as a fallback, not the centerpiece.** Climate, technology/AI, work and economy, health, family, etc. belong in the taxonomy when scenarios cover them, but only as many as the content warrants. Do not default to a "balanced" mix that dilutes the regional focus.
+- **Categorize by what the scenario is *about*, not by the medium it uses.** A scenario in which someone asks an AI assistant about getting through a checkpoint is about the checkpoint, not about AI. Only treat the medium as the topic when the technology itself is the substantive concern (e.g., surveillance, deepfakes destroying trust, AI replacing rabbinic authority).
+- **Avoid euphemism and avoid taking a political side in the labels.** Use names that participants from across the political spectrum would recognize as describing the same phenomenon. Where multiple framings exist, prefer the most neutral descriptive one.
+
+## Structural requirements
 
 1. Create 8-15 top-level **themes**. Each theme should represent a clearly distinct topic area.
-2. Under each theme, create 2-5 **sub-themes** that break the theme into more specific facets.
+2. Under each theme, create 2-6 **sub-themes** that break the theme into more specific facets.
 3. Themes must be **mutually exclusive** — a scenario should clearly belong to one primary theme, not ambiguously between two.
-4. Themes must be **collectively exhaustive** — together they should cover all plausible future scenario topics.
+4. Themes must be **collectively exhaustive** — together they should cover all plausible scenarios in the sample and similar ones.
 5. Themes should describe **topics** (what the scenario is about), not processes or dynamics.
 6. Each theme and sub-theme needs:
-   - A short name (2-4 words) in four languages: English, Dutch, Hebrew, Arabic
-   - A one-sentence English definition describing what scenarios belong in this category
+   - A short name (2-5 words) in four languages: English, Dutch, Hebrew, Arabic
+   - A one-sentence English definition describing what scenarios belong in this category. The definition should be concrete enough that an embedding generated from it lands close to scenarios that actually belong there.
 7. Avoid overly broad themes like "Society" or "Technology" — be specific enough to be useful, but broad enough to contain multiple scenarios.
 8. Avoid overly narrow themes that would only match one or two scenarios.
 
@@ -25,21 +35,21 @@ Return valid JSON in exactly this structure:
   "themes": [
     {
       "name": {
-        "english": "Climate & Environment",
-        "dutch": "Klimaat & Milieu",
-        "hebrew": "אקלים וסביבה",
-        "arabic": "المناخ والبيئة"
+        "english": "Conflict, Peace & Political Futures",
+        "dutch": "Conflict, Vrede & Politieke Toekomsten",
+        "hebrew": "סכסוך, שלום ועתידים פוליטיים",
+        "arabic": "الصراع والسلام والمستقبل السياسي"
       },
-      "definition": "Scenarios involving climate change, environmental degradation, natural disasters, or ecological adaptation",
+      "definition": "Scenarios imagining how the Israeli-Palestinian conflict evolves — escalation, settlement, partition, confederation, prolonged stalemate, or transformation of the political relationship between the two peoples",
       "sub_themes": [
         {
           "name": {
-            "english": "Natural Disasters",
-            "dutch": "Natuurrampen",
-            "hebrew": "אסונות טבע",
-            "arabic": "الكوارث الطبيعية"
+            "english": "Two-state / One-state / Confederation",
+            "dutch": "Twee staten / Eén staat / Confederatie",
+            "hebrew": "שתי מדינות / מדינה אחת / קונפדרציה",
+            "arabic": "دولتان / دولة واحدة / كونفدرالية"
           },
-          "definition": "Scenarios about floods, earthquakes, wildfires, storms, or other natural catastrophes and their aftermath"
+          "definition": "Scenarios that imagine a specific constitutional arrangement between Israelis and Palestinians, including formal peace agreements, annexation, partition, or shared sovereignty"
         }
       ]
     }
@@ -47,8 +57,10 @@ Return valid JSON in exactly this structure:
 }
 ```
 
+The example above shows the *style* of regional specificity expected; do not copy its themes verbatim. Derive the actual themes and sub-themes from the sample below.
+
 ## Sample Scenario Descriptions
 
-Here are representative descriptions from the dataset. Use them to understand the range of topics, but design categories that could also accommodate similar scenarios not shown here:
+Here are representative descriptions from the dataset. Use them to understand the range of topics, the relative weight of regional vs. generic concerns, and the specific framings participants are using. Design categories that could also accommodate similar scenarios not shown here:
 
 :DESCRIPTIONS:

--- a/functions/taxonomy/naming.py
+++ b/functions/taxonomy/naming.py
@@ -20,7 +20,7 @@ def generate_slug(name):
 
 def _call_llm(client, prompt):
     completion = client.chat.completions.create(
-        model="gpt-4.1",
+        model="gpt-5",
         messages=[{"role": "user", "content": prompt}],
         temperature=0.5,
         response_format={"type": "json_object"}

--- a/functions/taxonomy/naming.py
+++ b/functions/taxonomy/naming.py
@@ -20,9 +20,8 @@ def generate_slug(name):
 
 def _call_llm(client, prompt):
     completion = client.chat.completions.create(
-        model="gpt-5",
+        model="gpt-5.4",
         messages=[{"role": "user", "content": prompt}],
-        temperature=0.5,
         response_format={"type": "json_object"}
     )
     return json.loads(completion.choices[0].message.content)


### PR DESCRIPTION
## Summary
- Reworks `DESIGN_TAXONOMY_PROMPT.md` so the taxonomy is content-driven and prioritizes the Israeli-Palestinian conflict, Israeli politics & society, and Jewish identity — with generic themes (climate, tech, work, etc.) kept only as fallback. Proportions are left to GPT based on the sample.
- Reworks both screenshot describer prompts (`SCREENSHOT_DESCRIBER_PROMPT.md`, `AUTOMATIC_SCREENSHOT_DESCRIBER_PROMPT.md`) to enforce **content-over-template**: summaries, taglines, descriptions, and `future_scenario_topics` should describe what the scenario is *about*, not what kind of template was used. AI/social-media/notification framings are surfaced as topics only when the medium itself is the substantive concern.
- Bumps the four `gpt-4.1` call sites to `gpt-5`: `taxonomy/naming.py`, `screenshot_handler/__init__.py`, `cluster_screenshots/__init__.py`, `item_ingress_agent/__init__.py`. Updates `docs/API.md`, `docs/README.md`, and `functions/TEST_SUITE_README.md` to match.

## Behavior notes
- No code-shape changes; prompt placeholders (`:DESCRIPTIONS:`, `:PREVIOUS_TAXONOMY:`) and the JSON output schema are preserved, so `build_taxonomy` and the screenshot handler keep working without callsite updates.
- `redesign=false` keeps reusing the cached taxonomy. To see the new prompts in effect, run `POST /build_taxonomy?redesign=true` once.

## Test plan
- [x] `pytest tests/test_taxonomy.py tests/test_screenshot_handler.py` — 67 passed locally
- [ ] Run `POST /build_taxonomy?redesign=true` against a representative dataset and review the resulting themes/sub-themes
- [ ] Re-analyze a handful of items (`reanalyze_item`) including at least one AI-agent-query template to confirm the summary describes the user's concern rather than "AI usage"
- [ ] Spot-check that `gpt-5` works with the existing call shape (`temperature`, `response_format=json_object`, vision input); fall back to `gpt-5-mini` or `gpt-4o` if any callsite errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)