### PR TITLE
Bump deprecated GitHub Actions to current major versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,9 +8,9 @@ jobs:
     name: Deploy to Firebase
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: '18'
     - name: Install Firebase CLI
@@ -25,7 +25,7 @@ jobs:
     #     cat $GOOGLE_APPLICATION_CREDENTIALS | head -n 4
     #     # firebase login:ci
     - name: Set up python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.12'
     - name: Install dependencies


### PR DESCRIPTION
## Summary

Bumps three deprecated action pins in `.github/workflows/deploy.yml` from `@v2` to their current major versions, ahead of the Node.js 20 sunset.

## Why

GitHub posted a deprecation annotation on our most recent deploy run:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v2, actions/setup-node@v2, actions/setup-python@v2.

These actions will be forced to Node.js 24 starting **June 2nd, 2026** and removed **September 16th, 2026**. Better to upgrade now than be surprised in two weeks.

## Version table

| Action | Old | New |
| --- | --- | --- |
| `actions/checkout` | `@v2` | `@v4` |
| `actions/setup-node` | `@v2` | `@v4` |
| `actions/setup-python` | `@v2` | `@v5` |

`test.yml` was already on current-enough versions (`checkout@v3`, `setup-python@v4`) and is untouched.

`setup-node@v4` keeps `always-auth: false` default (unchanged from v2). `setup-python@v5` requires `python-version`, which is already set to `'3.12'`. No regressions expected.

## Test plan

- [ ] On merge: confirm the **Deploy the main branch** workflow runs green
- [ ] On next PR open: confirm **Run Tests** workflow still runs green (not modified, but worth eyeballing)
- [ ] No deprecation annotation in the next deploy run

🤖 Generated with [Claude Code](https://claude.com/claude-code)