### PR TITLE
Size the t-SNE grid to the number of records

### DIFF
--- a/functions/cluster_screenshots/calc_tsne.py
+++ b/functions/cluster_screenshots/calc_tsne.py
@@ -310,6 +310,7 @@ def cluster_screenshots_inner(config, params: TSNEParams, last_state_hash=None):
 
     yield dict(msg=f'Generating 2D representation from {len(records)} records.')
     X_2d = generate_tsne(activations, perplexity=min(params.PERPLEXITY, len(records)-1), tsne_iter=params.TSNE_ITER)
+    params.fit_grid_to_records(len(records))
     yield dict(msg="Generating image grid (%dx%d, %d images" % (params.OUT_DIM[0], params.OUT_DIM[1], len(records)))
     grid = calc_tsne_grid(X_2d, params.OUT_DIM)
     grid = grid[:len(records)]
@@ -365,7 +366,7 @@ if __name__ == '__main__':
 
     params = TSNEParams(
         OUT_RATIO = 25/43,
-        OUT_DIM_X = 32,
+        MAX_TO_PLOT = 460,
         CHRONOMAPS_API_URL='https://chronomaps-api-qjzuw7ypfq-ez.a.run.app',
         OPENAI_KEY=os.environ.get('OPENAI_KEY'),
         LOCAL= True,

--- a/functions/cluster_screenshots/tsne_params.py
+++ b/functions/cluster_screenshots/tsne_params.py
@@ -14,6 +14,7 @@ class TSNEParams():
     OUT_RATIO: float = 1.0
     PADDING_RATIO: float = 0.5
     FILL_RATIO: float = 0.75
+    MAX_TO_PLOT: int = 500
     SIDE: int = 1000
     TAG: str = None
     LOCAL: bool = False
@@ -24,12 +25,37 @@ class TSNEParams():
     CHRONOMAPS_API_URL: str = None
 
     def __post_init__(self):
-        self.OUT_DIM_Y = int(round(self.OUT_DIM_X * self.ORIGINAL_IMAGE_SIZE[0] * self.CELL_RATIOS[0] * self.OUT_RATIO / (self.ORIGINAL_IMAGE_SIZE[1] * self.CELL_RATIOS[1])))
+        # Cells are wider than they are tall (or vice versa) - this is the height/width
+        # ratio of the grid that keeps the map's overall proportions at OUT_RATIO.
+        self.GRID_ASPECT = self.ORIGINAL_IMAGE_SIZE[0] * self.CELL_RATIOS[0] * self.OUT_RATIO / (self.ORIGINAL_IMAGE_SIZE[1] * self.CELL_RATIOS[1])
+        self.TO_PLOT = self.MAX_TO_PLOT
+        self._set_out_dim(self.OUT_DIM_X)
+
+    def _set_out_dim(self, out_dim_x):
+        self.OUT_DIM_X = out_dim_x
+        self.OUT_DIM_Y = max(1, int(round(out_dim_x * self.GRID_ASPECT)))
         self.OUT_DIM = (self.OUT_DIM_X, self.OUT_DIM_Y)
-        self.TO_PLOT = int(self.OUT_DIM_X * self.OUT_DIM_Y * self.FILL_RATIO)
+
+    def fit_grid_to_records(self, num_records):
+        """Size the grid to hold num_records at the configured density (FILL_RATIO),
+        keeping the map's proportions. The grid always has at least one cell per record."""
+        target_cells = max(num_records, 1) / self.FILL_RATIO
+        start = max(1, int(round(math.sqrt(target_cells / self.GRID_ASPECT))))
+        # Both dimensions are rounded to whole cells, so the width closest to the ideal
+        # isn't necessarily the one that lands closest to the target density - look around it.
+        candidates = []
+        for out_dim_x in range(max(1, start - 2), start + 3):
+            out_dim_y = max(1, int(round(out_dim_x * self.GRID_ASPECT)))
+            cells = out_dim_x * out_dim_y
+            if cells >= num_records:
+                candidates.append((abs(cells - target_cells), out_dim_x))
+        self._set_out_dim(min(candidates)[1] if candidates else start)
+        while self.OUT_DIM_X * self.OUT_DIM_Y < num_records:
+            self._set_out_dim(self.OUT_DIM_X + 1)
+        return self.OUT_DIM
 
     def __str__(self):
         return f"TSNEParams(TAG={self.TAG}," +\
                f"ORIGINAL_IMAGE_SIZE={self.ORIGINAL_IMAGE_SIZE}, CELL_RATIOS={self.CELL_RATIOS}, " +\
-               f"BG_COLOR={self.BG_COLOR}, OUT_DIM_X={self.OUT_DIM_X}, OUT_RATIO={self.OUT_RATIO}, PADDING_RATIO={self.PADDING_RATIO}, " +\
-               f"FILL_RATIO={self.FILL_RATIO}, SIDE={self.SIDE}, V_OFFSET={self.V_OFFSET})"
+               f"BG_COLOR={self.BG_COLOR}, OUT_DIM={self.OUT_DIM}, OUT_RATIO={self.OUT_RATIO}, PADDING_RATIO={self.PADDING_RATIO}, " +\
+               f"FILL_RATIO={self.FILL_RATIO}, MAX_TO_PLOT={self.MAX_TO_PLOT}, SIDE={self.SIDE}, V_OFFSET={self.V_OFFSET})"


### PR DESCRIPTION
## What

The t-SNE grid was fixed at `OUT_DIM_X = 23` (23×20 cells), and that same constant capped how many records were plotted: `TO_PLOT = 23 * 20 * FILL_RATIO = 345`. Fewer records than that left a sparse map; more could never be plotted at all.

The grid now sizes itself to the actual record count, keeping the density (`FILL_RATIO`) as-is.

## How

**`tsne_params.py`**
- `MAX_TO_PLOT` (default **500**, was effectively 345) is the fetch/plot ceiling. `OUT_DIM_X` is now only the starting width, not a ceiling.
- `GRID_ASPECT` holds the cell height/width ratio (from `ORIGINAL_IMAGE_SIZE`, `CELL_RATIOS`, `OUT_RATIO`), so the map keeps its proportions at any size.
- `fit_grid_to_records(n)` targets `n / FILL_RATIO` cells and searches widths around `sqrt(target / aspect)` for the one landing closest to that target. It always guarantees `cells >= n` — `calc_tsne_grid` pads the `lapjv` cost matrix with `cells - n` zero columns and breaks otherwise.

**`calc_tsne.py`**
- Calls `params.fit_grid_to_records(len(records))` after the t-SNE projection, before `calc_tsne_grid`. Everything downstream (`create_tsne_image`, `info['dim']`, `conversion_ratio`, cluster bounds) already reads the actual dims, so it follows automatically.
- The local `__main__` block's `OUT_DIM_X = 32` becomes `MAX_TO_PLOT = 460`, reproducing its previous 32×16 / 460-record sizing exactly.

**Tiles are unchanged.** `create_tiles` sizes the pyramid off the rendered image, so it covers whatever grid comes out — smaller grids just yield fewer zoom levels (`min_zoom = 8 - zoom_level`), and `max_zoom` stays 8 so geo coordinates stay consistent.

## Resulting sizes

| records | grid | cells | fill |
|--------:|-----:|------:|-----:|
| 100 | 13×11 | 143 | 0.70 |
| 250 | 20×17 | 340 | 0.74 |
| 345 | 23×20 | 460 | 0.75 |
| 500 | 28×24 | 672 | 0.74 |

345 reproduces today's map exactly.

## Worth a look during review

- **Memory.** At the new 500-record cap the canvas is ~24300×24000 px ≈ 1.75 GB as numpy, roughly doubled at peak by the `Image.fromarray` copy in the tiling step — vs ~1.2 GB / 2.4 GB peak today. `cluster_its_time` runs at `MemoryOption.GB_8`, so it should fit, but 500 is close to the practical edge. Lower `MAX_TO_PLOT` if OOMs show up.
- **Density wobble.** With both dimensions rounded to whole cells, actual fill lands in ~0.69–0.83 rather than exactly 0.75. Unavoidable on a small integer grid; the search minimizes the deviation.

## Testing

Verified `fit_grid_to_records` across record counts (table above) and confirmed the `cells >= records` invariant holds. Not run end to end: `lapjv` isn't installed in the venv and no tests cover the t-SNE path.

Separately — `main` currently doesn't compile: `d4cf541 "fix crash"` left a missing colon at `calc_tsne.py:115` (`if filename is not None`). Not touched by this PR, but it'll need fixing before this branch can run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)