### PR TITLE
Add per-database global key-value store

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -69,7 +69,7 @@ Authorization: Bearer <firebase-token>
 ```
 Authorization: Bearer <db-key>
 ```
-When the target database's `config/config` document defines a `key`, that value can be sent as a bearer token in place of a Firebase ID token on any endpoint that normally requires Firebase auth (`GET /`, `POST /`, `GET /all-items`, `POST /build_taxonomy`). The override is per-database — each db has its own `key`. Configure or rotate it by writing to `config/config` in that db.
+When the target database's `config/config` document defines a `key`, that value can be sent as a bearer token in place of a Firebase ID token on any endpoint that normally requires Firebase auth (`GET /`, `POST /`, `GET /all-items`, `PUT /global/<key>`, `POST /build_taxonomy`). The override is per-database — each db has its own `key`. Configure or rotate it by writing to `config/config` in that db.
 
 ### Workspace Keys
 
@@ -136,6 +136,57 @@ GET /config
 ```
 
 If the `config/config` document does not exist, or has no `metadata` field, the endpoint returns `{"metadata": {}}` with status 200.
+
+---
+
+### Global Key-Value Store
+
+A per-database key-value store. Values are scoped to the target database (selected with `?db=`), not to a workspace. Admins write; anyone can read.
+
+#### Set Global Key
+
+```http
+PUT /global/<key>
+POST /global/<key>
+Authorization: Bearer <firebase-token | db-key>
+Content-Type: application/json
+
+<any JSON value>
+```
+
+**Authentication**: Firebase Bearer Token (admin users only) or the database bearer key
+
+**Description**: Stores the request body as the value for `<key>` in the target database, overwriting any previous value. The body must be valid JSON and may be any JSON type (object, array, string, number, boolean, `null`). The value is persisted as a JSON-encoded string in the `global_keys/<key>` document, along with `updated_at` and `updated_by`.
+
+Keys are URL path segments: non-empty, no `/`, at most 1500 bytes, and not of the form `__name__`.
+
+**Response** (200):
+```json
+{
+  "key": "featured_workspace",
+  "value": {"id": "abc123", "title": "Spring 2026"},
+  "updated_at": "2026-08-21T10:00:00+00:00"
+}
+```
+
+**Errors**: `400` invalid key or non-JSON body, `401` not authenticated / not an admin.
+
+#### Read Global Key
+
+```http
+GET /global/<key>
+```
+
+**Authentication**: None (public endpoint)
+
+**Description**: Returns the stored JSON value for `<key>` as the response body (`Content-Type: application/json`). The body is the value itself, not wrapped in an envelope.
+
+**Response** (200):
+```json
+{"id": "abc123", "title": "Spring 2026"}
+```
+
+**Errors**: `404` if the key has not been set in this database.
 
 ---
 
@@ -1164,7 +1215,12 @@ Firebase Storage bucket: `chronomaps3-eu`
    - `key` (string, optional): bearer-token override for Firebase-auth endpoints (see [Authorization Methods](#authorization-methods))
    - `metadata` (object, optional): public, human-readable metadata returned by [`GET /config`](#get-database-metadata)
 
-4. **`chronomaps_global`** - Cross-workspace data
+4. **`global_keys`** - Per-database public key-value store (see [Global Key-Value Store](#global-key-value-store)). One document per key:
+   - `value` (string): the JSON-encoded value
+   - `updated_at` (string): ISO timestamp of the last write
+   - `updated_by` (string): email of the admin who wrote it (or `db-key`)
+
+5. **`chronomaps_global`** - Cross-workspace data
    - `taxonomy` document - Hierarchical taxonomy reference (see [Taxonomy Document](#taxonomy-document))
    - `embedding-<hash>` documents - Cached reference embeddings for taxonomy sub-themes
 

--- a/functions/chronomaps_api/__init__.py
+++ b/functions/chronomaps_api/__init__.py
@@ -361,6 +361,46 @@ def get_db_config():
         return flask.jsonify({"metadata": {}}), 200
     return flask.jsonify({"metadata": (doc.to_dict() or {}).get('metadata', {})}), 200
 
+# Per-database global key-value store.
+# Documents live in the `global_keys` collection of the target db, one per key:
+#   { "value": <JSON-encoded string>, "updated_at": <iso>, "updated_by": <email> }
+GLOBAL_KEYS_COLLECTION = 'global_keys'
+
+def _validate_global_key(key):
+    if not key or len(key.encode('utf-8')) > 1500 or key in ('.', '..') or (key.startswith('__') and key.endswith('__')):
+        flask.abort(400, "Invalid key")
+
+@app.put("/global/<key>")
+@app.post("/global/<key>")
+@require_firebase_auth
+def set_global_key(key):
+    """Set a db-wide key. Body is the JSON value to store (any JSON type)."""
+    _validate_global_key(key)
+    raw = flask.request.get_data(as_text=True)
+    try:
+        value = json.loads(raw)
+    except (TypeError, ValueError):
+        flask.abort(400, "Request body must be valid JSON")
+    updated_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    flask.g.db.collection(GLOBAL_KEYS_COLLECTION).document(key).set({
+        "value": json.dumps(value, ensure_ascii=False),
+        "updated_at": updated_at,
+        "updated_by": flask.g.firebase_user.get("email"),
+    })
+    return {"key": key, "value": value, "updated_at": updated_at}, 200
+
+@app.get("/global/<key>")
+def read_global_key(key):
+    """Read a db-wide key. Public. Returns the stored JSON value as the response body."""
+    _validate_global_key(key)
+    doc = flask.g.db.collection(GLOBAL_KEYS_COLLECTION).document(key).get()
+    if not doc.exists:
+        return flask.jsonify({"error": "Key not found"}), 404
+    stored = (doc.to_dict() or {}).get("value")
+    if not isinstance(stored, str):
+        return flask.jsonify({"error": "Key not found"}), 404
+    return app.response_class(stored, status=200, mimetype='application/json')
+
 @app.get("/all-items")
 @require_firebase_auth
 def get_all_items():

--- a/functions/tests/test_chronomaps_api.py
+++ b/functions/tests/test_chronomaps_api.py
@@ -1653,5 +1653,133 @@ class TestDbKeyAuthOverride:
             mock_verify.assert_called_once()
 
 
+class TestGlobalKeys:
+    """Test the per-db global key-value store: PUT/POST /global/<key> (admin) and GET /global/<key> (public)."""
+
+    def _setup(self, mock_db, stored=None, exists=True):
+        """Route `config/config` to a db-key config doc and `global_keys/<k>` to a key doc."""
+        cfg_doc = Mock()
+        cfg_doc.exists = True
+        cfg_doc.to_dict.return_value = {"key": "the-db-key", "admins": []}
+        cfg_ref = Mock()
+        cfg_ref.get.return_value = cfg_doc
+
+        key_doc = Mock()
+        key_doc.exists = exists
+        key_doc.to_dict.return_value = stored
+        key_ref = Mock()
+        key_ref.get.return_value = key_doc
+
+        def collection_side_effect(name):
+            coll = Mock()
+            coll.document.return_value = cfg_ref if name == "config" else key_ref
+            return coll
+        mock_db.collection.side_effect = collection_side_effect
+        return key_ref
+
+    def test_set_stores_json_string(self, client, mock_db):
+        key_ref = self._setup(mock_db)
+        value = {"hello": "world", "n": [1, 2, 3]}
+        response = client.put(
+            "/global/my-key",
+            headers={"Authorization": "Bearer the-db-key"},
+            json=value,
+        )
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert data["key"] == "my-key"
+        assert data["value"] == value
+        assert "updated_at" in data
+
+        key_ref.set.assert_called_once()
+        written = key_ref.set.call_args[0][0]
+        assert isinstance(written["value"], str)
+        assert json.loads(written["value"]) == value
+        assert written["updated_by"] == "db-key"
+        assert "updated_at" in written
+
+    def test_set_via_post(self, client, mock_db):
+        key_ref = self._setup(mock_db)
+        response = client.post(
+            "/global/k",
+            headers={"Authorization": "Bearer the-db-key"},
+            json="just a string",
+        )
+        assert response.status_code == 200
+        assert json.loads(key_ref.set.call_args[0][0]["value"]) == "just a string"
+
+    def test_set_requires_auth(self, client, mock_db):
+        key_ref = self._setup(mock_db)
+        response = client.put("/global/my-key", json={"a": 1})
+        assert response.status_code == 401
+        key_ref.set.assert_not_called()
+
+    def test_set_rejects_wrong_token(self, client, mock_db):
+        key_ref = self._setup(mock_db)
+        with patch('chronomaps_api.resolve_firebase_user.verify_id_token', side_effect=Exception("bad")):
+            response = client.put(
+                "/global/my-key",
+                headers={"Authorization": "Bearer nope"},
+                json={"a": 1},
+            )
+        assert response.status_code == 401
+        key_ref.set.assert_not_called()
+
+    def test_set_rejects_invalid_json_body(self, client, mock_db):
+        key_ref = self._setup(mock_db)
+        response = client.put(
+            "/global/my-key",
+            headers={"Authorization": "Bearer the-db-key"},
+            data="not json {",
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+        key_ref.set.assert_not_called()
+
+    def test_set_rejects_invalid_key(self, client, mock_db):
+        key_ref = self._setup(mock_db)
+        response = client.put(
+            "/global/__reserved__",
+            headers={"Authorization": "Bearer the-db-key"},
+            json=1,
+        )
+        assert response.status_code == 400
+        key_ref.set.assert_not_called()
+
+    def test_read_returns_value_publicly(self, client, mock_db):
+        value = {"hello": "world", "n": [1, 2, 3]}
+        self._setup(mock_db, stored={"value": json.dumps(value), "updated_at": "x", "updated_by": "y"})
+        # No Authorization header.
+        response = client.get("/global/my-key")
+        assert response.status_code == 200
+        assert response.mimetype == "application/json"
+        assert json.loads(response.data) == value
+
+    def test_read_scalar_value(self, client, mock_db):
+        self._setup(mock_db, stored={"value": json.dumps(42)})
+        response = client.get("/global/answer")
+        assert response.status_code == 200
+        assert json.loads(response.data) == 42
+
+    def test_read_missing_key_404(self, client, mock_db):
+        self._setup(mock_db, stored=None, exists=False)
+        response = client.get("/global/nope")
+        assert response.status_code == 404
+
+    def test_read_uses_global_keys_collection(self, client, mock_db):
+        self._setup(mock_db, stored={"value": "null"})
+        client.get("/global/some-key")
+        mock_db.collection.assert_any_call("global_keys")
+
+    def test_read_honors_db_param(self, client):
+        mock = Mock()
+        doc = Mock()
+        doc.exists = False
+        mock.collection.return_value.document.return_value.get.return_value = doc
+        with patch('chronomaps_api.firestore.client', return_value=mock) as client_factory:
+            client.get("/global/k?db=staging")
+            client_factory.assert_called_with(database_id="staging")
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- `PUT /global/<key>` (also `POST`): admin-only write (Firebase admin token or the db's `config/config.key` bearer). Request body is any JSON value; it's stored as a JSON-encoded string in the target db's `global_keys/<key>` document along with `updated_at` / `updated_by`.
- `GET /global/<key>`: public read; returns the stored JSON value verbatim as the response body (`404` if unset).
- Scoped per database via the existing `?db=` parameter, not per workspace.
- Docs: new "Global Key-Value Store" section in `docs/API.md`, plus auth-methods and Firestore-collections updates.

## Notes
- Keys are validated against Firestore doc-id constraints (non-empty, no `/`, ≤1500 bytes, not `__x__`).
- `/global/<key>` takes precedence over `/<workspace>/<item_id>`, so a workspace literally named `global` would have item GET shadowed (same caveat as existing `items` / `temporary-collaboration` paths).
- No delete/list endpoints — only set and read.

## Test plan
- [x] `pytest functions/tests/test_chronomaps_api.py` — 82 passed (11 new in `TestGlobalKeys`: round-trip, JSON-string storage, auth required/rejected, bad JSON, bad key, scalar values, 404, collection name, `?db=` routing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LonUKK1oPJH51arSC59xH4