### PR TITLE
Add Dropbox auto-ingest for scanned pages

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1014,6 +1014,126 @@ This endpoint is also called automatically by `screenshot_handler` and `reanalyz
 
 ---
 
+## Dropbox Auto-Ingest
+
+Scanned pages that land in a Dropbox folder are ingested automatically: cropped to the expected page
+proportions, uploaded through `screenshot_handler` in automatic mode, and tagged so all pages from a
+single scan batch share one `author_id`.
+
+### How a folder is picked up
+
+The ingest lists the immediate subfolders of `DROPBOX_ROOT_PATH`. A subfolder is ingested only if:
+
+1. It contains a **credentials file** at its root — `chronomaps.config`, `.chronomaps.config` or
+   `chronomaps.txt` (first match wins), and
+2. It was **created after `DROPBOX_FOLDER_CUTOFF`** (default `2026-08-20T00:00:00Z`). Dropbox exposes
+   no folder creation time, so the oldest `server_modified` in the folder is used as the proxy. Set
+   `ignore_cutoff: true` in the credentials file to backfill an older folder deliberately.
+
+Images are collected recursively below the folder (`.jpg`, `.jpeg`, `.png`).
+
+### Credentials file
+
+JSON, or simple `key: value` lines (`#` comments allowed):
+
+```
+workspace: 0a698fad-7e49-428f-bceb-c9d51b3512e1
+api_key: <collaborate or admin key>
+
+# optional
+enabled: true               # false disables the folder without deleting the file
+ignore_cutoff: false        # true ingests a folder created before the cutoff
+batch_gap_seconds: 120      # a longer gap between scans starts a new author batch
+ratio: 0.53                 # target width/height
+ratio_tolerance: 0.10       # images further off than this are skipped
+max_uploads_per_run: 50     # remaining images are picked up on the next run
+time_source: auto           # auto | client | server — which Dropbox timestamp is "scan time"
+rotate_landscape: off       # off | cw | ccw — rescue landscape scans by rotating them
+```
+
+### State file
+
+`chronomaps.state.json` is written next to the credentials file and is what prevents re-uploads:
+
+```json
+{
+  "version": 1,
+  "workspace": "<workspace-id>",
+  "files":   {"<dropbox content_hash>": {"path": "...", "item_id": "...", "author_id": "...",
+                                          "scanned_at": "...", "uploaded_at": "..."}},
+  "skipped": {"<dropbox content_hash>": {"path": "...", "reason": "aspect ratio ...", "at": "..."}},
+  "failed":  {"<dropbox content_hash>": {"path": "...", "error": "...", "attempts": 1, "at": "..."}},
+  "recent_batches": [{"author_id": "<uuid4>", "first_scanned_at": "...", "last_scanned_at": "..."}]
+}
+```
+
+- Dedup is keyed on Dropbox's own `content_hash`, so a re-uploaded or moved copy of the same bytes is
+  recognised without downloading it. Two copies of the same bytes in one folder (a Dropbox
+  "conflicted copy") upload once.
+- A `files` entry with a `metadata_error` means the item was created but its `author_id` could not be
+  attached. It is deliberately not retried — retrying would create a second item — so fix it by
+  PUTting the metadata onto the recorded `item_id`.
+- `failed` entries are retried on later runs and quarantined after 3 attempts; a quarantined file is
+  reported (`action: quarantined`) on every subsequent run. Delete the entry to force a retry.
+- Deleting the whole file causes the folder to be ingested again from scratch.
+
+### Batching and `author_id`
+
+Scans are ordered by **scan time** (`client_modified`, falling back to `server_modified`). A gap
+longer than `batch_gap_seconds` starts a new batch, and each batch gets one `uuid4` `author_id` that
+is written to every item in it. The last 10 batches are kept in `recent_batches` with their scan
+windows, so a page that syncs an hour late rejoins *its own* batch rather than whichever one was
+processed most recently. Files that reached Dropbox less than `DROPBOX_SETTLE_SECONDS` ago (default
+180) are left for the next run so a batch mid-sync is not split.
+
+### Image preprocessing
+
+Images are centre-cropped to `ratio` (0.53 width:height, matching the scanner UI) and rejected —
+recorded under `skipped` — when the ratio is further than `ratio_tolerance` from the target, when the
+shortest side is under 300px, or when the file is unreadable or over 30MB. Accepted images are fit
+into 2120x4000 and re-encoded as JPEG q85, the same preprocessing the batch uploader uses. Contrast
+and white balance are left to the existing `enhance_image` step.
+
+### Upload path
+
+Per image, identical to the app's automatic mode:
+
+```http
+POST {SCREENSHOT_HANDLER_URL}?workspace=<id>&api_key=<key>&automatic=true
+Content-Type: multipart/form-data     (field: image)
+
+PUT {CHRONOMAPS_API_URL}/<workspace>/<item_id>?item-key=<item_key>
+Authorization: <api_key>
+
+{"author_id": "<batch uuid4>", "source": "dropbox", "dropbox_path": "...",
+ "dropbox_content_hash": "...", "scanned_at": "..."}
+```
+
+Bookkeeping metadata goes in the `PUT`, never in the handler's `metadata` form field — that field is
+fed to the vision model as user-provided truth.
+
+### Triggers
+
+```http
+POST /dropbox_ingest?dry_run=<bool>&folder=<folder-name>
+Authorization: Bearer <firebase-token>
+```
+
+**Authentication**: Firebase admin token (`shared.verify_firebase_admin`)
+
+**Description**: Runs the ingest immediately. `dry_run=true` reports what would be uploaded without
+uploading anything or writing state files; `folder` limits the run to one workspace folder. Returns
+the array of per-step status objects.
+
+`dropbox_ingest_scheduled` runs the same flow every 5 minutes. Both take a Firestore lock
+(`chronomaps_global/dropbox_ingest_lock`) so two runs never ingest concurrently, and both stop
+starting new work after `DROPBOX_RUN_DEADLINE_SECONDS` (default 1500) so an interrupted chunk cannot
+be re-uploaded by the next run.
+
+Locally, the same code path runs via `python dropbox_ingest_cli.py --dry-run [--folder NAME]`.
+
+---
+
 ## Data Models
 
 ### Workspace Configuration
@@ -1276,6 +1396,44 @@ Required secrets for Firebase Cloud Functions:
 - `CHRONOMAPS_API_URL` - Base URL for the Chronomaps API
 - `SERVICE_ACCOUNT_JSON` - Firebase service account credentials
 - `CONFIG__ITS_TIME` - Configuration for scheduled clustering job
+
+Required for the Dropbox auto-ingest — **secrets** (Secret Manager, set with
+`firebase functions:secrets:set`):
+
+- `DROPBOX_APP_KEY` / `DROPBOX_APP_SECRET` - Dropbox scoped app credentials
+- `DROPBOX_REFRESH_TOKEN` - Long-lived token (mint it with `scripts/dropbox_authorize.py`)
+
+And **non-secret configuration**, kept in `functions/.env.chronomaps3` so deploys from CI need no
+manual setup:
+
+- `DROPBOX_ROOT_PATH` - Folder holding the per-workspace subfolders
+- `DROPBOX_FOLDER_CUTOFF` - ISO timestamp; folders older than this are ignored
+- `DROPBOX_NAMESPACE_ID` - Only for a Dropbox Business team space (`scripts/dropbox_check.py`
+  prints the value when it is needed)
+- `DROPBOX_SETTLE_SECONDS` - Optional; how long a file must be settled before ingest (default 180)
+- `DROPBOX_RUN_DEADLINE_SECONDS` - Optional; stop starting work after this long (default 1500)
+- `SCREENSHOT_HANDLER_URL` - Optional; derived from `CHRONOMAPS_API_URL` when both follow the
+  standard naming, required otherwise
+
+### First-time setup
+
+1. Create a **scoped** app at https://www.dropbox.com/developers/apps with **Full Dropbox** access
+   (an *App folder* app can never see a folder that already exists elsewhere).
+2. On its *Permissions* tab enable `account_info.read`, `files.metadata.read`, `files.content.read`
+   and `files.content.write`, then Submit — before minting any token, or the token will not carry
+   the scopes.
+3. On its *Settings* tab set **Access token expiration: Short-lived**, leave **Redirect URIs empty**
+   (the setup script uses the copy-the-code flow) and leave *Allow public clients* disallowed — the
+   ingest authenticates with the app secret. Webhooks are not used; the function polls. The app can
+   stay in *Development* status: it is linked to a single account.
+4. `python scripts/dropbox_authorize.py --app-key KEY --app-secret SECRET` and follow the prompts.
+   Authorize with the account that can see the scan folder — for a team space, that is the member
+   whose token the namespace id in step 6 belongs to. Regenerating the app secret later invalidates
+   the refresh token.
+5. Store the three credentials as secrets, put the root path in `functions/.env.chronomaps3`.
+6. `python scripts/dropbox_check.py` — verifies auth, detects a team namespace, and lists which
+   folders would be ingested and why the others would not.
+7. `python dropbox_ingest_cli.py --dry-run` for a per-image preview before anything is uploaded.
 
 ---
 

--- a/docs/DROPBOX_SETUP.md
+++ b/docs/DROPBOX_SETUP.md
@@ -1,0 +1,163 @@
+# Setting up the Dropbox auto-ingest
+
+How to connect a Dropbox folder of scanned pages to Chronomaps, from nothing. Follow it once per
+Dropbox account; adding further workshop folders afterwards is only step 7.
+
+What the ingest does, in one line: every few minutes it looks at the subfolders of one Dropbox
+folder, and for each one that holds a credentials file, uploads new scans to that workspace — cropped
+to the page ratio, deduplicated, with one shared `author_id` per scan batch. The reference for its
+behaviour is [API.md](API.md#dropbox-auto-ingest); this document is only the setup.
+
+You will need: admin access to the Dropbox account that receives the scans, and permission to write
+secrets in the `chronomaps3` Firebase project.
+
+---
+
+## 1. Create the Dropbox app
+
+At https://www.dropbox.com/developers/apps → **Create app**:
+
+| Field | Value | Why |
+|---|---|---|
+| API | **Scoped access** | The only option that supports refresh tokens |
+| Access | **Full Dropbox** | An *App folder* app can only see its own folder, never an archive that already exists |
+| Name | e.g. `chronomaps-ingest` | Must be globally unique |
+
+## 2. Grant permissions — before minting any token
+
+*Permissions* tab, tick exactly these, then **Submit**:
+
+```
+account_info.read      files.metadata.read      files.content.read      files.content.write
+```
+
+`content.write` is needed only to write `chronomaps.state.json` (the record of what has been
+uploaded) back into each folder. `account_info.read` lets the setup check detect a team space.
+
+A token minted before this tab is submitted silently lacks the scopes, and the failure surfaces much
+later as a 401 in the middle of an ingest. `scripts/dropbox_authorize.py` warns if it happens.
+
+## 3. Settings tab
+
+- **Access token expiration: Short-lived.** This is what makes the OAuth flow return a refresh token.
+- **Redirect URIs: leave empty.** The setup script uses the copy-the-code flow; adding a redirect URI
+  means both the authorize call and the token exchange have to send it.
+- **Allow public clients (Implicit Grant & PKCE): Disallow.** The ingest authenticates with the app
+  secret.
+- Ignore the *Generated access token* button — that is a manual short-lived token, not what we need.
+- **Webhooks: none.** The function polls; a webhook would need a public unauthenticated endpoint that
+  answers Dropbox's `?challenge=` handshake.
+- The app can stay in **Development** status: it is linked to a single account, well under the 50-user
+  limit, so no App Review is needed.
+
+Copy the **App key** and **App secret** into files, e.g. `../dropbox-app-key.txt` and
+`../dropbox-app-secret.txt` (outside the repo).
+
+## 4. Mint the refresh token
+
+```bash
+# print the URL to approve
+python scripts/dropbox_authorize.py \
+    --key-file ../dropbox-app-key.txt --secret-file ../dropbox-app-secret.txt --url-only
+
+# exchange the code Dropbox shows you
+python scripts/dropbox_authorize.py \
+    --key-file ../dropbox-app-key.txt --secret-file ../dropbox-app-secret.txt \
+    --code <CODE> --output ../dropbox-refresh-token.txt
+```
+
+Approve as the account that can actually see the scan folder. The code is single-use and expires in
+minutes; get a fresh one if it goes stale. Prefer the `--*-file` and `--output` options over passing
+and printing values: arguments are visible in the process list, and the refresh token is a long-lived
+credential that should not sit in terminal scrollback.
+
+## 5. Store the credentials
+
+```bash
+firebase functions:secrets:set DROPBOX_APP_KEY       --project chronomaps3 --data-file ../dropbox-app-key.txt
+firebase functions:secrets:set DROPBOX_APP_SECRET    --project chronomaps3 --data-file ../dropbox-app-secret.txt
+firebase functions:secrets:set DROPBOX_REFRESH_TOKEN --project chronomaps3 --data-file ../dropbox-refresh-token.txt
+```
+
+Non-secret configuration lives in `functions/.env.chronomaps3`, which is committed so a deploy from
+CI needs no manual setup:
+
+```
+DROPBOX_ROOT_PATH=/futuring_workshops_archive
+DROPBOX_FOLDER_CUTOFF=2026-08-20T00:00:00Z
+# DROPBOX_NAMESPACE_ID=        # only for a team space — step 6 tells you
+```
+
+## 6. Verify the connection
+
+```bash
+export DROPBOX_APP_KEY="$(cat ../dropbox-app-key.txt)"
+export DROPBOX_APP_SECRET="$(cat ../dropbox-app-secret.txt)"
+export DROPBOX_REFRESH_TOKEN="$(cat ../dropbox-refresh-token.txt)"
+export DROPBOX_ROOT_PATH=/futuring_workshops_archive
+python scripts/dropbox_check.py
+```
+
+It authenticates, reports whether a **team space** is in play, and lists every subfolder with the
+reason it would or would not be ingested. If the root folder cannot be listed but the account has a
+team space, uncomment `DROPBOX_NAMESPACE_ID` with the value the script prints: members of a Dropbox
+team have a personal home *and* a team space, and paths resolve against home unless a path root is
+set — a folder in the team space is otherwise simply invisible.
+
+## 7. Enable a workshop folder
+
+Create a file named `chronomaps.config` in the folder (`.chronomaps.config` and `chronomaps.txt`
+also work). Both fields come from the workspace's auto-input link
+(`https://mapfutur.es/?workspace=<workspace>&api_key=<key>&automatic=true`):
+
+```
+workspace: 00000000-1111-2222-3333-444444444444
+api_key: 55555555-6666-7777-8888-999999999999
+```
+
+Two things to know about the key:
+
+- The **collaborate** key is enough for the whole ingest path, and is the right choice because the
+  archive is usually a *shared* Dropbox folder — anyone with folder access can read this file. An
+  admin key there would hand them full control of the workspace, including deleting every item.
+- A collaborate key is only accepted **while collaboration is enabled on the workspace**. If it is
+  off, every image fails with 403. Enable it in the admin UI, or use the admin key instead.
+
+Optional settings, all with sensible defaults — see [API.md](API.md#credentials-file) for the list.
+The one worth knowing is `ignore_cutoff: true`, needed to ingest a folder whose existing scans
+predate `DROPBOX_FOLDER_CUTOFF`.
+
+## 8. Preview, then run
+
+```bash
+python dropbox_ingest_cli.py --dry-run --folder "<folder name>"   # uploads nothing, writes nothing
+python dropbox_ingest_cli.py --folder "<folder name>"             # for real
+```
+
+The dry run lists candidates and their batch grouping. It does not download images, so it cannot
+show which will be rejected for their aspect ratio — that appears in the real run.
+
+Once the function is deployed, `dropbox_ingest_scheduled` does this every 5 minutes on its own.
+`POST /dropbox_ingest?dry_run=true&folder=<name>` (with an admin Firebase token) runs it on demand.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause |
+|---|---|
+| `Token refresh failed: 400 invalid_client` | App key/secret mismatch, or the secret was regenerated — re-run step 4 |
+| Root folder cannot be listed | Path typo, or the folder is in the team space — set `DROPBOX_NAMESPACE_ID` (step 6) |
+| `401` mid-ingest | Token minted before permissions were submitted — re-run step 4 |
+| Every image errors with 403 | Collaboration disabled on the workspace, or a stale key in `chronomaps.config` |
+| Folder is listed as "before the cutoff" | It already contained scans older than `DROPBOX_FOLDER_CUTOFF`; add `ignore_cutoff: true` |
+| `action: quarantined` in the output | A file failed 3 times and is no longer retried; fix the cause, then delete its entry from `chronomaps.state.json` |
+| An image was uploaded twice | Should not happen — check whether `chronomaps.state.json` was deleted or the folder was copied |
+| Nothing at all is ingested | No credentials file in any folder; `scripts/dropbox_check.py` says which folders are skipped and why |
+
+## Rotating or revoking access
+
+Regenerating the app secret, or disconnecting the app under
+https://www.dropbox.com/account/connected_apps, invalidates the refresh token immediately — the
+ingest then fails on every run until step 4 is repeated. To stop ingest for one folder without
+touching credentials, put `enabled: false` in its `chronomaps.config`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ This directory contains comprehensive documentation for the Chronomaps Server AP
 ## Contents
 
 - [API.md](API.md) - Complete API reference documentation
+- [DROPBOX_SETUP.md](DROPBOX_SETUP.md) - Connecting a Dropbox folder of scans to a workspace
 
 ## Overview
 
@@ -23,6 +24,7 @@ Chronomaps Server is a Firebase Cloud Functions-based backend for managing colla
 - Fine-grained access control (5-level privilege system)
 - AI-powered screenshot analysis using GPT-5.4 Vision
 - Modular image operations (replace image, re-analyze item)
+- Dropbox auto-ingest of scanned pages (batch-aware, deduplicated)
 - Interactive chat agent for guided item completion
 - ML clustering (t-SNE + Agglomerative Clustering)
 - Map tile generation for visualization

--- a/dropbox_ingest_cli.py
+++ b/dropbox_ingest_cli.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Run the Dropbox → Chronomaps ingest locally.
+
+Same code path as the deployed function, so this is the way to preview (and
+first-run) an ingest before the schedule takes over.
+
+Usage:
+  python dropbox_ingest_cli.py --dry-run                 # preview everything
+  python dropbox_ingest_cli.py --folder "25-08-21 ABC"   # ingest one folder
+  python dropbox_ingest_cli.py                           # ingest all eligible folders
+
+Configuration comes from the environment (or --env-file), the same variables the
+Cloud Function receives as secrets:
+  DROPBOX_APP_KEY, DROPBOX_APP_SECRET, DROPBOX_REFRESH_TOKEN, DROPBOX_ROOT_PATH,
+  CHRONOMAPS_API_URL, and optionally DROPBOX_NAMESPACE_ID, DROPBOX_FOLDER_CUTOFF,
+  DROPBOX_SETTLE_SECONDS, SCREENSHOT_HANDLER_URL.
+"""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent / 'functions'))
+
+from dropbox_ingest import ConfigurationError, load_settings, run_ingest  # noqa: E402
+from dropbox_ingest.dropbox_api import DropboxError  # noqa: E402
+
+
+def load_env_file(path):
+    """Read a simple KEY=VALUE file into the environment."""
+    for line in Path(path).read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith('#') or '=' not in line:
+            continue
+        key, value = line.split('=', 1)
+        os.environ.setdefault(key.strip(), value.strip().strip('"\''))
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Ingest scanned pages from Dropbox into Chronomaps')
+    parser.add_argument('--dry-run', action='store_true',
+                        help='List what would be uploaded without uploading or writing state')
+    parser.add_argument('--folder', help='Only process this workspace folder (by name)')
+    parser.add_argument('--env-file', help='Read configuration from a KEY=VALUE file first')
+    parser.add_argument('--json', action='store_true', help='Emit raw JSON lines instead of a summary')
+    args = parser.parse_args()
+
+    if args.env_file:
+        load_env_file(args.env_file)
+
+    try:
+        settings = load_settings()
+    except ConfigurationError as e:
+        parser.error(str(e))
+
+    counts = {}
+    try:
+        for bit in run_ingest(settings=settings, dry_run=args.dry_run, only_folder=args.folder):
+            counts[bit.get('action')] = counts.get(bit.get('action'), 0) + 1
+            print(json.dumps(bit, ensure_ascii=False) if args.json else format_line(bit))
+    except (DropboxError, ConfigurationError) as e:
+        print(f'\nDropbox ingest failed: {e}', file=sys.stderr)
+        return 2
+
+    print('\nSummary: ' + ', '.join(f'{action}={count}' for action, count in sorted(counts.items())))
+    return 1 if counts.get('error') else 0
+
+
+def format_line(bit):
+    action = bit.get('action')
+    folder = bit.get('folder', '')
+    if action == 'start':
+        return f"→ root {bit['root']}, cutoff {bit['cutoff']}{' (DRY RUN)' if bit['dry_run'] else ''}"
+    if action == 'skip-folder':
+        return f"   skip  {folder}: {bit['reason']}"
+    if action == 'folder':
+        line = (f"── {folder} → workspace {bit['workspace']} (created {bit['created_at']}): "
+                f"{bit['images']} images, {bit['new']} new, {bit['ready']} ready, "
+                f"{bit['syncing']} still syncing")
+        if bit.get('duplicates'):
+            line += f", {bit['duplicates']} duplicate copies"
+        if bit.get('quarantined'):
+            line += f", {bit['quarantined']} quarantined"
+        return line
+    if action == 'would-upload':
+        return f"   plan  {bit['path']}  scanned {bit['scanned_at']}  author {bit['author_id'][:8]}"
+    if action == 'uploaded':
+        line = f"   ok    {bit['path']}  item {bit['item_id']}  author {bit['author_id'][:8]}"
+        if bit.get('metadata_error'):
+            line += f"  (metadata NOT set: {bit['metadata_error']})"
+        return line
+    if action == 'skip-image':
+        return f"   skip  {bit['path']}: {bit['reason']}"
+    if action == 'quarantined':
+        return (f"   HELD  {bit['path']}: failed {bit['attempts']}x, no longer retried "
+                f"({bit.get('error')})")
+    if action == 'deadline':
+        return f"   time  stopping early, {bit['deferred']} left for the next run"
+    if action == 'capped':
+        return f"   cap   {folder}: {bit['deferred']} files deferred to the next run"
+    if action == 'error':
+        return f"   ERR   {bit.get('path', folder)}: {bit['error']}"
+    if action == 'folder-done':
+        return f"   done  {folder}: {bit['uploaded']} processed"
+    if action == 'done':
+        return f"→ finished, {bit['folders']} folders considered"
+    return json.dumps(bit, ensure_ascii=False)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/functions/.env.chronomaps3
+++ b/functions/.env.chronomaps3
@@ -1,0 +1,17 @@
+# Non-secret configuration for the chronomaps3 project.
+# Firebase loads this at deploy time and sets each value as an environment
+# variable on every function. Credentials do NOT belong here — those are
+# Secret Manager entries (see DROPBOX_INGEST_SECRETS in main.py).
+
+# Dropbox folder holding one subfolder per workspace.
+DROPBOX_ROOT_PATH=/futuring_workshops_archive
+
+# Folders whose oldest content predates this are treated as pre-existing.
+DROPBOX_FOLDER_CUTOFF=2026-08-20T00:00:00Z
+
+# Set only for a Dropbox Business team space; `scripts/dropbox_check.py` prints
+# the value to use when it is needed.
+# DROPBOX_NAMESPACE_ID=
+
+# Only needed if the screenshot handler URL cannot be derived from CHRONOMAPS_API_URL.
+# SCREENSHOT_HANDLER_URL=https://screenshot-handler-qjzuw7ypfq-ez.a.run.app

--- a/functions/dropbox_ingest/__init__.py
+++ b/functions/dropbox_ingest/__init__.py
@@ -1,0 +1,680 @@
+"""Auto-ingest scanned pages from Dropbox into Chronomaps workspaces.
+
+Flow, per run:
+
+1. List the immediate subfolders of the configured Dropbox root. Each subfolder
+   is a candidate workspace.
+2. A subfolder is ingested only if it holds a credentials file (workspace id +
+   api key) and was created after the configured cutoff date.
+3. New images (not recorded in the folder's state file) that have finished
+   syncing are grouped into scan batches by time gap; every image in a batch
+   gets the same `author_id`.
+4. Each image is centre-cropped to the 0.53:1 page ratio (or rejected), then
+   uploaded through the same endpoints the screenshots app uses in auto mode:
+   POST screenshot_handler?automatic=true, then PUT the bookkeeping metadata.
+5. The state file in the Dropbox folder is updated so nothing is uploaded twice.
+
+Everything is driven by injected settings/client objects so the flow can run
+from the scheduled Cloud Function, the HTTP trigger or the local CLI.
+"""
+
+import datetime
+import json
+import os
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from io import BytesIO
+
+import requests
+
+from .dropbox_api import DropboxClient, DropboxConflict, DropboxError, parse_timestamp
+from .images import ImageRejected, RATIO_TOLERANCE, TARGET_RATIO, prepare_image
+
+CONFIG_FILENAMES = ('chronomaps.config', '.chronomaps.config', 'chronomaps.txt')
+STATE_FILENAME = 'chronomaps.state.json'
+IMAGE_EXTENSIONS = ('.jpg', '.jpeg', '.png')
+
+DEFAULT_FOLDER_CUTOFF = '2026-08-20T00:00:00Z'
+DEFAULT_SETTLE_SECONDS = 180      # let a multi-page scan finish syncing before batching it
+DEFAULT_BATCH_GAP_SECONDS = 120   # a gap longer than this starts a new author batch
+DEFAULT_MAX_UPLOADS_PER_RUN = 50
+MAX_FILE_ATTEMPTS = 3             # failures are retried across runs, then quarantined
+MAX_TRACKED_BATCHES = 10          # how many recent batches stay joinable by late-syncing pages
+UPLOAD_WORKERS = 4
+# State is written after every chunk, so an interrupted run can re-upload at
+# most one chunk's worth of images; keeping it at the worker count means no
+# upload sits unrecorded while its neighbours are still in flight.
+STATE_FLUSH_EVERY = UPLOAD_WORKERS
+STATE_VERSION = 1
+DEFAULT_RUN_DEADLINE_SECONDS = 1500   # leave headroom under the function's 1800s timeout
+
+UPLOAD_TIMEOUT = (30, 300)
+
+
+class ConfigurationError(Exception):
+    """The ingest is not configured well enough to run."""
+
+
+@dataclass
+class Settings:
+    """Deployment-wide configuration (secrets / env vars)."""
+    app_key: str
+    app_secret: str
+    refresh_token: str
+    root_path: str
+    namespace_id: str = ''
+    folder_cutoff: datetime.datetime = None
+    settle_seconds: int = DEFAULT_SETTLE_SECONDS
+    chronomaps_api_url: str = ''
+    screenshot_handler_url: str = ''
+    run_deadline_seconds: int = DEFAULT_RUN_DEADLINE_SECONDS
+
+
+@dataclass
+class FolderConfig:
+    """Per-folder configuration, read from the credentials file."""
+    workspace: str
+    api_key: str
+    enabled: bool = True
+    ignore_cutoff: bool = False
+    batch_gap_seconds: int = DEFAULT_BATCH_GAP_SECONDS
+    ratio: float = TARGET_RATIO
+    ratio_tolerance: float = RATIO_TOLERANCE
+    max_uploads_per_run: int = DEFAULT_MAX_UPLOADS_PER_RUN
+    time_source: str = 'auto'          # auto | client | server
+    rotate_landscape: str = 'off'      # off | cw | ccw
+    extra: dict = field(default_factory=dict)
+
+
+def load_settings(env=None):
+    """Build Settings from environment variables (Cloud Function secrets or CLI env)."""
+    env = env if env is not None else os.environ
+    app_key = env.get('DROPBOX_APP_KEY', '').strip()
+    app_secret = env.get('DROPBOX_APP_SECRET', '').strip()
+    refresh_token = env.get('DROPBOX_REFRESH_TOKEN', '').strip()
+    root_path = env.get('DROPBOX_ROOT_PATH', '').strip()
+    missing = [name for name, value in (
+        ('DROPBOX_APP_KEY', app_key),
+        ('DROPBOX_APP_SECRET', app_secret),
+        ('DROPBOX_REFRESH_TOKEN', refresh_token),
+        ('DROPBOX_ROOT_PATH', root_path),
+    ) if not value]
+    if missing:
+        raise ConfigurationError(f'Missing configuration: {", ".join(missing)}')
+
+    api_url = env.get('CHRONOMAPS_API_URL', '').strip()
+    if not api_url:
+        raise ConfigurationError('Missing configuration: CHRONOMAPS_API_URL')
+    handler_url = env.get('SCREENSHOT_HANDLER_URL', '').strip() or derive_handler_url(api_url)
+
+    return Settings(
+        app_key=app_key,
+        app_secret=app_secret,
+        refresh_token=refresh_token,
+        root_path=root_path,
+        namespace_id=env.get('DROPBOX_NAMESPACE_ID', '').strip(),
+        folder_cutoff=parse_timestamp(env.get('DROPBOX_FOLDER_CUTOFF', '').strip() or DEFAULT_FOLDER_CUTOFF),
+        settle_seconds=int(env.get('DROPBOX_SETTLE_SECONDS', '') or DEFAULT_SETTLE_SECONDS),
+        chronomaps_api_url=api_url.rstrip('/'),
+        screenshot_handler_url=handler_url,
+        run_deadline_seconds=int(env.get('DROPBOX_RUN_DEADLINE_SECONDS', '') or DEFAULT_RUN_DEADLINE_SECONDS),
+    )
+
+
+def derive_handler_url(api_url):
+    """The screenshot handler lives beside the API, under both URL schemes.
+
+    Cloud Run:       https://chronomaps-api-<hash>-ez.a.run.app
+    Cloud Functions: https://<region>-<project>.cloudfunctions.net/chronomaps_api
+
+    A wrong guess here would POST every scan at the API root and fail silently
+    until every page is quarantined, so an unrecognised URL is an error and the
+    operator sets SCREENSHOT_HANDLER_URL explicitly.
+    """
+    url = api_url.rstrip('/')
+    if 'chronomaps-api' in url:
+        return url.replace('chronomaps-api', 'screenshot-handler')
+    if url.endswith('/chronomaps_api'):
+        return url[:-len('/chronomaps_api')] + '/screenshot_handler'
+    raise ConfigurationError(
+        f'Cannot derive the screenshot handler URL from CHRONOMAPS_API_URL ({api_url}) — '
+        'set SCREENSHOT_HANDLER_URL explicitly')
+
+
+def make_client(settings):
+    return DropboxClient(settings.app_key, settings.app_secret, settings.refresh_token,
+                         namespace_id=settings.namespace_id or None)
+
+
+# -- credentials file -------------------------------------------------------
+
+def parse_credentials(text):
+    """Parse a credentials file: JSON object, or simple `key: value` lines.
+
+    Raises ConfigurationError when the workspace id or api key is missing.
+    """
+    values = {}
+    stripped = text.strip()
+    if stripped.startswith('{'):
+        try:
+            values = json.loads(stripped)
+        except ValueError as e:
+            raise ConfigurationError(f'credentials file is not valid JSON ({e})')
+    else:
+        for line in stripped.splitlines():
+            line = line.strip()
+            if not line or line.startswith('#'):
+                continue
+            separator = ':' if ':' in line else ('=' if '=' in line else None)
+            if not separator:
+                continue
+            key, value = line.split(separator, 1)
+            values[key.strip().lower()] = value.strip().strip('"\'')
+
+    values = {str(k).strip().lower(): v for k, v in values.items()}
+    workspace = str(values.pop('workspace', '') or values.pop('workspace_id', '') or '').strip()
+    api_key = str(values.pop('api_key', '') or values.pop('apikey', '') or values.pop('key', '') or '').strip()
+    if not workspace or not api_key:
+        raise ConfigurationError('credentials file must define `workspace` and `api_key`')
+
+    return FolderConfig(
+        workspace=workspace,
+        api_key=api_key,
+        enabled=_as_bool(values.pop('enabled', True), True),
+        ignore_cutoff=_as_bool(values.pop('ignore_cutoff', False), False),
+        batch_gap_seconds=_as_number(values, 'batch_gap_seconds', DEFAULT_BATCH_GAP_SECONDS, int),
+        ratio=_as_number(values, 'ratio', TARGET_RATIO, float),
+        ratio_tolerance=_as_number(values, 'ratio_tolerance', RATIO_TOLERANCE, float),
+        max_uploads_per_run=_as_number(values, 'max_uploads_per_run', DEFAULT_MAX_UPLOADS_PER_RUN, int),
+        time_source=str(values.pop('time_source', 'auto')).lower(),
+        rotate_landscape=str(values.pop('rotate_landscape', 'off')).lower(),
+        extra=values,
+    )
+
+
+def _as_number(values, key, default, cast):
+    """Read a numeric setting, reporting a typo as a folder problem.
+
+    A stray `ratio: 0,53` must fail this one folder, not raise ValueError out of
+    the whole scheduled run.
+    """
+    raw = values.pop(key, default)
+    try:
+        return cast(raw)
+    except (TypeError, ValueError):
+        raise ConfigurationError(f'`{key}` must be a number, got {raw!r}')
+
+
+def _as_bool(value, default):
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    return str(value).strip().lower() in ('1', 'true', 'yes', 'on')
+
+
+# -- state file -------------------------------------------------------------
+
+def empty_state(workspace):
+    return {
+        'version': STATE_VERSION,
+        'workspace': workspace,
+        'files': {},
+        'skipped': {},
+        'failed': {},
+        'recent_batches': [],
+    }
+
+
+def read_state(client, folder_path, workspace):
+    """Return `(state, rev)`; rev is None when there is no state file yet."""
+    path = f'{folder_path}/{STATE_FILENAME}'
+    metadata = client.get_metadata(path)
+    if not metadata:
+        return empty_state(workspace), None
+    try:
+        state = json.loads(client.download(path).decode('utf-8'))
+    except ValueError:
+        # A corrupt state file would silently re-upload everything; refuse instead.
+        raise ConfigurationError(f'{path} exists but is not valid JSON — fix or delete it')
+    for key in ('files', 'skipped', 'failed'):
+        state.setdefault(key, {})
+    state.setdefault('version', STATE_VERSION)
+    state.setdefault('workspace', workspace)
+    state['recent_batches'] = _read_batches(state)
+    return state, metadata.get('rev')
+
+
+def _read_batches(state):
+    """Batch history, migrating the older single-`last_batch` shape."""
+    batches = state.pop('last_batch', None)
+    if state.get('recent_batches'):
+        return state['recent_batches']
+    if batches:
+        return [{'author_id': batches['author_id'],
+                 'first_scanned_at': batches.get('first_scanned_at') or batches['last_scanned_at'],
+                 'last_scanned_at': batches['last_scanned_at']}]
+    return []
+
+
+def merge_states(remote, local):
+    """Union two states, preferring `local` for entries present in both."""
+    merged = dict(remote)
+    for key in ('files', 'skipped', 'failed'):
+        combined = dict(remote.get(key) or {})
+        combined.update(local.get(key) or {})
+        merged[key] = combined
+    merged['version'] = STATE_VERSION
+    merged['workspace'] = local.get('workspace') or remote.get('workspace')
+    merged.pop('last_batch', None)
+    merged['recent_batches'] = merge_batches(_read_batches(dict(remote)), _read_batches(dict(local)))
+    return merged
+
+
+def merge_batches(existing, additions, limit=MAX_TRACKED_BATCHES):
+    """Fold batches into the history, widening the range of ones already known."""
+    by_author = {}
+    for batch in list(existing or []) + list(additions or []):
+        current = by_author.get(batch['author_id'])
+        if current:
+            current['first_scanned_at'] = min(current['first_scanned_at'], batch['first_scanned_at'])
+            current['last_scanned_at'] = max(current['last_scanned_at'], batch['last_scanned_at'])
+        else:
+            by_author[batch['author_id']] = dict(batch)
+    ordered = sorted(by_author.values(), key=lambda b: b['last_scanned_at'])
+    return ordered[-limit:]
+
+
+def batches_from(assignments):
+    """Summarise `(entry, scan_time, author_id)` tuples as batch ranges."""
+    batches = {}
+    for _entry, stamp, author_id in assignments:
+        stamp = _iso(stamp)
+        batch = batches.setdefault(author_id, {'author_id': author_id,
+                                               'first_scanned_at': stamp, 'last_scanned_at': stamp})
+        batch['first_scanned_at'] = min(batch['first_scanned_at'], stamp)
+        batch['last_scanned_at'] = max(batch['last_scanned_at'], stamp)
+    return list(batches.values())
+
+
+def write_state(client, folder_path, state, rev, attempts=3):
+    """Persist the state file, merging in concurrent writes on conflict."""
+    path = f'{folder_path}/{STATE_FILENAME}'
+    for attempt in range(attempts):
+        payload = json.dumps(state, indent=2, ensure_ascii=False, sort_keys=True).encode('utf-8')
+        try:
+            result = client.upload(path, payload, rev=rev)
+            return state, result.get('rev')
+        except DropboxConflict:
+            if attempt == attempts - 1:
+                raise
+            remote_state, rev = read_state(client, folder_path, state.get('workspace'))
+            state = merge_states(remote_state, state)
+    raise DropboxError(f'Could not write {path}')
+
+
+# -- listing / eligibility --------------------------------------------------
+
+def is_image(entry):
+    return (entry.get('.tag') == 'file'
+            and entry.get('name', '').lower().endswith(IMAGE_EXTENSIONS))
+
+
+def find_config_entry(entries, folder_path):
+    """The credentials file must sit at the folder root, not in a subfolder."""
+    root = folder_path.lower().rstrip('/')
+    by_name = {}
+    for entry in entries:
+        if entry.get('.tag') != 'file':
+            continue
+        path = entry.get('path_lower', '')
+        if path.rsplit('/', 1)[0] != root:
+            continue
+        by_name[entry['name'].lower()] = entry
+    for name in CONFIG_FILENAMES:
+        if name in by_name:
+            return by_name[name]
+    return None
+
+
+def folder_created_at(entries):
+    """Proxy for folder creation: the oldest `server_modified` it contains.
+
+    The Dropbox API exposes no creation time for folders, and `server_modified`
+    is the time Dropbox received the file — so a folder whose oldest content
+    arrived after the cutoff was itself created after the cutoff.
+    """
+    times = [parse_timestamp(e.get('server_modified'))
+             for e in entries if e.get('.tag') == 'file' and e.get('server_modified')]
+    times = [t for t in times if t]
+    return min(times) if times else None
+
+
+def scan_time(entry, time_source='auto'):
+    """When the page was scanned, as opposed to when Dropbox received it."""
+    client_time = parse_timestamp(entry.get('client_modified'))
+    server_time = parse_timestamp(entry.get('server_modified'))
+    if time_source == 'server':
+        return server_time or client_time
+    if time_source == 'client':
+        return client_time or server_time
+    return client_time or server_time
+
+
+def entry_key(entry):
+    """Dedup key: Dropbox's content hash, falling back to the path."""
+    return entry.get('content_hash') or 'path:' + (entry.get('path_lower') or '')
+
+
+def is_known(state, content_hash):
+    """Has this exact content been handled (or given up on) already?"""
+    if content_hash in (state.get('files') or {}):
+        return True
+    if content_hash in (state.get('skipped') or {}):
+        return True
+    failed = (state.get('failed') or {}).get(content_hash)
+    return bool(failed and failed.get('attempts', 0) >= MAX_FILE_ATTEMPTS)
+
+
+def assign_batches(entries, recent_batches, gap_seconds, time_source='auto'):
+    """Group scans into batches by time gap and hand each batch one author id.
+
+    Returns `(assignments, batches)` where assignments are
+    `(entry, scan_time, author_id)` tuples in scan order.
+
+    Batches are matched against a window of recent ones rather than only the
+    latest, so when a run ingests batch A and then batch B, a page of A that
+    syncs an hour late still rejoins A instead of being glued onto B.
+    """
+    ordered = sorted(entries, key=lambda e: (scan_time(e, time_source), e.get('path_lower', '')))
+    batches = [dict(b) for b in (recent_batches or [])]
+
+    assignments = []
+    for entry in ordered:
+        stamp = scan_time(entry, time_source)
+        batch = _closest_batch(batches, stamp, gap_seconds)
+        if batch is None:
+            batch = {'author_id': str(uuid.uuid4()),
+                     'first_scanned_at': _iso(stamp), 'last_scanned_at': _iso(stamp)}
+            batches.append(batch)
+        else:
+            batch['first_scanned_at'] = min(batch['first_scanned_at'], _iso(stamp))
+            batch['last_scanned_at'] = max(batch['last_scanned_at'], _iso(stamp))
+        assignments.append((entry, stamp, batch['author_id']))
+
+    return assignments, merge_batches(batches, [])
+
+
+def _closest_batch(batches, stamp, gap_seconds):
+    """The batch whose scan window this page falls closest to, within the gap."""
+    best, best_distance = None, None
+    for batch in batches:
+        first = parse_timestamp(batch['first_scanned_at'])
+        last = parse_timestamp(batch['last_scanned_at'])
+        if first <= stamp <= last:
+            distance = 0
+        else:
+            distance = min(abs((stamp - first).total_seconds()), abs((stamp - last).total_seconds()))
+        if distance <= gap_seconds and (best_distance is None or distance < best_distance):
+            best, best_distance = batch, distance
+    return best
+
+
+def _iso(value):
+    return value.isoformat().replace('+00:00', 'Z') if value else None
+
+
+def _now():
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+# -- upload -----------------------------------------------------------------
+
+def upload_scan(settings, config, image_bytes, filename, author_id, metadata, session=None):
+    """Upload one prepared image, the same way the app does in auto mode.
+
+    POST to the screenshot handler with `automatic=true` (which analyses the
+    image and creates the item), then PUT the bookkeeping metadata onto the new
+    item — deliberately not via the handler's `metadata` form field, which is
+    fed to the vision prompt as user-provided truth.
+    """
+    http = session or requests
+    response = http.post(
+        settings.screenshot_handler_url,
+        files={'image': (filename, BytesIO(image_bytes), 'image/jpeg')},
+        params={'workspace': config.workspace, 'api_key': config.api_key, 'automatic': 'true'},
+        timeout=UPLOAD_TIMEOUT,
+    )
+    if response.status_code != 200:
+        raise RuntimeError(f'screenshot_handler returned {response.status_code}: {response.text[:500]}')
+    payload = response.json()
+    item_id = payload.get('item_id') or (payload.get('metadata') or {}).get('item_id')
+    item_key = payload.get('item_key') or (payload.get('metadata') or {}).get('item_key')
+    if not item_id:
+        raise RuntimeError(f'screenshot_handler returned no item_id: {str(payload)[:500]}')
+
+    # Mirrors screenshot_handler.update_item, without pulling in its Firebase deps.
+    update = http.put(
+        f'{settings.chronomaps_api_url}/{config.workspace}/{item_id}',
+        json=dict(metadata, author_id=author_id),
+        headers={'Authorization': config.api_key},
+        params={'item-key': item_key} if item_key else None,
+        timeout=UPLOAD_TIMEOUT,
+    )
+    # The item already exists at this point, so a failed PUT is reported rather
+    # than raised: retrying the upload would create a duplicate item.
+    metadata_error = None
+    if update.status_code >= 400:
+        metadata_error = f'metadata update returned {update.status_code}: {update.text[:500]}'
+    return item_id, item_key, metadata_error
+
+
+# -- per-folder flow --------------------------------------------------------
+
+def process_folder(client, folder, settings, dry_run=False, now=None, session=None, deadline=None):
+    """Ingest one workspace folder, yielding status dicts as it goes."""
+    now = now or _now()
+    folder_path = folder.get('path_display') or folder.get('path_lower')
+    name = folder.get('name', folder_path)
+
+    entries = list(client.list_folder(folder_path, recursive=True))
+    config_entry = find_config_entry(entries, folder.get('path_lower', folder_path))
+    if not config_entry:
+        yield dict(folder=name, action='skip-folder', reason='no credentials file')
+        return
+
+    try:
+        config = parse_credentials(
+            client.download(config_entry['path_display']).decode('utf-8', errors='replace'))
+    except ConfigurationError as e:
+        yield dict(folder=name, action='skip-folder', reason=f'bad credentials file: {e}')
+        return
+
+    if not config.enabled:
+        yield dict(folder=name, action='skip-folder', reason='disabled in credentials file')
+        return
+
+    created_at = folder_created_at(entries)
+    if not config.ignore_cutoff and settings.folder_cutoff and created_at and created_at < settings.folder_cutoff:
+        yield dict(folder=name, action='skip-folder',
+                   reason=f'created {_iso(created_at)}, before cutoff {_iso(settings.folder_cutoff)}')
+        return
+
+    state, rev = read_state(client, folder_path, config.workspace)
+
+    images = [e for e in entries if is_image(e)]
+
+    # Duplicates within one listing (Dropbox "conflicted copy" files, a folder
+    # copied in twice) share a content hash, and the state file has one record
+    # per hash — uploading both would create two items and record only one.
+    fresh, duplicates, seen = [], [], set()
+    for entry in images:
+        key = entry_key(entry)
+        if is_known(state, key):
+            continue
+        if key in seen:
+            duplicates.append(entry)
+            continue
+        seen.add(key)
+        fresh.append(entry)
+
+    settle_before = now - datetime.timedelta(seconds=settings.settle_seconds)
+    ready, syncing = [], []
+    for entry in fresh:
+        server_time = parse_timestamp(entry.get('server_modified'))
+        (syncing if server_time and server_time > settle_before else ready).append(entry)
+
+    quarantined = [e for e in images
+                   if (state['failed'].get(entry_key(e)) or {}).get('attempts', 0) >= MAX_FILE_ATTEMPTS]
+
+    yield dict(folder=name, action='folder', workspace=config.workspace,
+               created_at=_iso(created_at), images=len(images), new=len(fresh),
+               ready=len(ready), syncing=len(syncing), duplicates=len(duplicates),
+               quarantined=len(quarantined))
+
+    # Quarantined pages are invisible to every later run, so say so every time.
+    for entry in quarantined:
+        record = state['failed'][entry_key(entry)]
+        yield dict(folder=name, action='quarantined', path=entry.get('path_display'),
+                   attempts=record.get('attempts'), error=record.get('error'))
+
+    if not ready:
+        return
+
+    assignments, _batches = assign_batches(ready, state.get('recent_batches'),
+                                           config.batch_gap_seconds, config.time_source)
+    capped = assignments[:config.max_uploads_per_run]
+    if len(assignments) > len(capped):
+        yield dict(folder=name, action='capped', limit=config.max_uploads_per_run,
+                   deferred=len(assignments) - len(capped))
+
+    if dry_run:
+        for entry, stamp, author_id in capped:
+            yield dict(folder=name, action='would-upload', path=entry.get('path_display'),
+                       scanned_at=_iso(stamp), author_id=author_id)
+        return
+
+    processed = 0
+    for chunk in _chunks(capped, STATE_FLUSH_EVERY):
+        if deadline is not None and time.monotonic() > deadline:
+            yield dict(folder=name, action='deadline', deferred=len(capped) - processed)
+            break
+        results = _process_chunk(client, chunk, config, settings, session, name)
+        for result in results:
+            _record(state, result, now)
+            processed += 1
+            yield result
+        # Only the batches this chunk actually covered — claiming the whole run's
+        # batches here would make a late-syncing page miss its own batch.
+        state['recent_batches'] = merge_batches(state.get('recent_batches'), batches_from(chunk))
+        state, rev = write_state(client, folder_path, state, rev)
+
+    yield dict(folder=name, action='folder-done', uploaded=processed)
+
+
+def _process_chunk(client, chunk, config, settings, session, folder_name):
+    """Download, crop and upload a chunk of scans concurrently."""
+    def handle(assignment):
+        entry, stamp, author_id = assignment
+        base = dict(folder=folder_name, workspace=config.workspace, path=entry.get('path_display'),
+                    content_hash=entry_key(entry), scanned_at=_iso(stamp), author_id=author_id)
+        try:
+            data = client.download(entry['path_display'])
+            expected = entry.get('size')
+            if expected is not None and len(data) != expected:
+                # A short read is transient: record it as a failure to retry,
+                # never as a rejected image (which would be permanent).
+                raise IOError(f'downloaded {len(data)} bytes, expected {expected}')
+            image_bytes, info = prepare_image(
+                data, ratio=config.ratio, tolerance=config.ratio_tolerance,
+                rotate_landscape=config.rotate_landscape)
+        except ImageRejected as e:
+            return dict(base, action='skip-image', reason=e.reason)
+        except Exception as e:                                  # noqa: BLE001 - reported, retried next run
+            return dict(base, action='error', error=f'{type(e).__name__}: {e}')
+
+        try:
+            item_id, item_key, metadata_error = upload_scan(
+                settings, config, image_bytes, entry['name'], author_id,
+                metadata=dict(source='dropbox', dropbox_path=entry.get('path_display'),
+                              dropbox_content_hash=entry.get('content_hash'),
+                              scanned_at=_iso(stamp)),
+                session=session)
+        except Exception as e:                                  # noqa: BLE001 - reported, retried next run
+            return dict(base, action='error', error=f'{type(e).__name__}: {e}')
+        result = dict(base, action='uploaded', item_id=item_id, item_key=item_key, **info)
+        if metadata_error:
+            result['metadata_error'] = metadata_error
+        return result
+
+    with ThreadPoolExecutor(max_workers=UPLOAD_WORKERS) as pool:
+        return list(pool.map(handle, chunk))
+
+
+def _record(state, result, now):
+    """Fold one file's outcome into the state file."""
+    content_hash = result.get('content_hash')
+    if not content_hash:
+        return
+    stamp = _iso(now)
+    if result['action'] == 'uploaded':
+        # Recorded even when the metadata PUT failed: the item exists, so a
+        # retry would duplicate it rather than repair it.
+        record = dict(path=result.get('path'), item_id=result.get('item_id'),
+                      author_id=result.get('author_id'),
+                      scanned_at=result.get('scanned_at'), uploaded_at=stamp)
+        if result.get('metadata_error'):
+            record['metadata_error'] = result['metadata_error']
+        state['files'][content_hash] = record
+        state['failed'].pop(content_hash, None)
+    elif result['action'] == 'skip-image':
+        state['skipped'][content_hash] = dict(path=result.get('path'),
+                                              reason=result.get('reason'), at=stamp)
+        state['failed'].pop(content_hash, None)
+    else:
+        previous = state['failed'].get(content_hash) or {}
+        state['failed'][content_hash] = dict(path=result.get('path'), error=result.get('error'),
+                                             attempts=previous.get('attempts', 0) + 1, at=stamp)
+
+
+def _chunks(items, size):
+    for start in range(0, len(items), size):
+        yield items[start:start + size]
+
+
+# -- entry point ------------------------------------------------------------
+
+def run_ingest(settings=None, client=None, dry_run=False, only_folder=None, now=None, session=None):
+    """Ingest every eligible workspace folder under the Dropbox root."""
+    settings = settings or load_settings()
+    client = client or make_client(settings)
+    now = now or _now()
+
+    deadline = time.monotonic() + settings.run_deadline_seconds
+
+    yield dict(action='start', root=settings.root_path, dry_run=dry_run,
+               cutoff=_iso(settings.folder_cutoff))
+
+    folders = [e for e in client.list_folder(settings.root_path) if e.get('.tag') == 'folder']
+    if only_folder:
+        wanted = only_folder.strip('/').lower()
+        folders = [f for f in folders if f.get('name', '').lower() == wanted
+                   or (f.get('path_lower') or '').strip('/') == wanted]
+
+    processed = 0
+    for folder in folders:
+        if time.monotonic() > deadline:
+            yield dict(action='deadline', deferred=len(folders) - processed)
+            break
+        processed += 1
+        try:
+            yield from process_folder(client, folder, settings, dry_run=dry_run, now=now,
+                                      session=session, deadline=deadline)
+        except Exception as e:                                  # noqa: BLE001
+            # One folder's problem (a corrupt state file, a Dropbox hiccup)
+            # must never stop the other workspaces from being ingested.
+            yield dict(folder=folder.get('name'), action='error', error=f'{type(e).__name__}: {e}')
+
+    yield dict(action='done', folders=len(folders))

--- a/functions/dropbox_ingest/dropbox_api.py
+++ b/functions/dropbox_ingest/dropbox_api.py
@@ -1,0 +1,303 @@
+"""Minimal Dropbox HTTP API client.
+
+Only the handful of endpoints the ingest flow needs, built on `requests` to
+match the rest of this codebase (see `screenshot_handler`) and to avoid pulling
+in the official SDK.
+
+Auth uses the "scoped app + refresh token" flow: a long-lived refresh token is
+exchanged for short-lived access tokens, which are cached in-process.
+"""
+
+import base64
+import datetime
+import json
+import threading
+import time
+
+import requests
+
+API_BASE = 'https://api.dropboxapi.com'
+CONTENT_BASE = 'https://content.dropboxapi.com'
+OAUTH_TOKEN_URL = 'https://api.dropbox.com/oauth2/token'
+
+# Scopes needed by the ingest flow (used by scripts/dropbox_authorize.py too).
+# account_info.read is what lets the setup check detect a team space, where the
+# ingest has to address folders through a namespace root.
+SCOPES = 'account_info.read files.metadata.read files.content.read files.content.write'
+
+DEFAULT_TIMEOUT = (30, 300)
+MAX_RETRIES = 4
+
+
+class DropboxError(Exception):
+    """A Dropbox API call failed."""
+
+    def __init__(self, message, status_code=None, body=None):
+        super().__init__(message)
+        self.status_code = status_code
+        self.body = body
+
+    @property
+    def summary(self):
+        """The `error_summary` string Dropbox returns, when there is one."""
+        if isinstance(self.body, dict):
+            return self.body.get('error_summary', '')
+        return ''
+
+
+class DropboxConflict(DropboxError):
+    """A write lost a race (rev mismatch) and must be retried."""
+
+
+def parse_timestamp(value):
+    """Parse a Dropbox ISO-8601 timestamp (always UTC, 'Z' suffixed)."""
+    if not value:
+        return None
+    return datetime.datetime.fromisoformat(value.replace('Z', '+00:00'))
+
+
+class DropboxClient:
+    """Thin wrapper over the Dropbox v2 HTTP API."""
+
+    def __init__(self, app_key, app_secret, refresh_token, namespace_id=None, session=None):
+        self.app_key = app_key
+        self.app_secret = app_secret
+        self.refresh_token = refresh_token
+        self.namespace_id = namespace_id
+        # Downloads run on a worker pool and requests.Session is not documented
+        # as thread-safe, so each thread gets its own (unless one is injected).
+        self._shared_session = session
+        self._local = threading.local()
+        self._token_lock = threading.Lock()
+        self._token = None
+        self._token_expires_at = 0
+
+    @property
+    def session(self):
+        if self._shared_session is not None:
+            return self._shared_session
+        if not hasattr(self._local, 'session'):
+            self._local.session = requests.Session()
+        return self._local.session
+
+    # -- auth ---------------------------------------------------------------
+
+    def access_token(self):
+        """Return a valid access token, refreshing it when close to expiry.
+
+        Locked: without it, a pool of workers hitting an expired token would
+        fire one OAuth refresh each and get rate limited.
+        """
+        with self._token_lock:
+            if self._token and time.time() < self._token_expires_at - 60:
+                return self._token
+            return self._refresh_token()
+
+    def _refresh_token(self):
+        response = self.session.post(
+            OAUTH_TOKEN_URL,
+            data={'grant_type': 'refresh_token', 'refresh_token': self.refresh_token},
+            auth=(self.app_key, self.app_secret),
+            timeout=DEFAULT_TIMEOUT,
+        )
+        if response.status_code != 200:
+            raise DropboxError(f'Token refresh failed: {response.status_code} {response.text}',
+                               response.status_code)
+        payload = response.json()
+        self._token = payload['access_token']
+        self._token_expires_at = time.time() + payload.get('expires_in', 14400)
+        return self._token
+
+    def _headers(self, extra=None):
+        headers = {'Authorization': f'Bearer {self.access_token()}'}
+        if self.namespace_id:
+            headers['Dropbox-API-Path-Root'] = json.dumps(
+                {'.tag': 'namespace_id', 'namespace_id': self.namespace_id})
+        if extra:
+            headers.update(extra)
+        return headers
+
+    # -- transport ----------------------------------------------------------
+
+    def _request(self, url, *, headers=None, json_body=None, data=None, stream=False):
+        """POST to Dropbox, retrying rate limits and transient 5xx responses."""
+        last_error = None
+        for attempt in range(MAX_RETRIES):
+            try:
+                response = self.session.post(
+                    url,
+                    headers=self._headers(headers),
+                    json=json_body,
+                    data=data,
+                    timeout=DEFAULT_TIMEOUT,
+                    stream=stream,
+                )
+            except requests.RequestException as e:
+                # Connection resets and read timeouts are expected over a long
+                # run; surface them as DropboxError so callers can keep going.
+                last_error = DropboxError(f'{type(e).__name__}: {e}')
+                time.sleep(2 ** attempt)
+                continue
+            if response.status_code == 200:
+                return response
+            body = _safe_json(response)
+            if response.status_code == 429:
+                delay = _retry_after(response, body, attempt)
+                last_error = DropboxError('Rate limited', 429, body)
+                time.sleep(delay)
+                continue
+            if response.status_code >= 500:
+                last_error = DropboxError(f'Server error: {response.text}', response.status_code, body)
+                time.sleep(2 ** attempt)
+                continue
+            if response.status_code == 401:
+                # Token may have been revoked mid-run; force a refresh once.
+                self._token = None
+                last_error = DropboxError('Unauthorized', 401, body)
+                if attempt == 0:
+                    continue
+            error = DropboxError(f'{response.status_code}: {response.text}', response.status_code, body)
+            if response.status_code == 409 and 'conflict' in error.summary:
+                raise DropboxConflict(str(error), 409, body)
+            raise error
+        raise last_error
+
+    # -- endpoints ----------------------------------------------------------
+
+    def list_folder(self, path, recursive=False):
+        """Yield entry dicts for `path`, following the cursor to the end."""
+        payload = {
+            'path': _normalize_path(path),
+            'recursive': recursive,
+            'include_deleted': False,
+            'include_media_info': False,
+            'limit': 2000,
+        }
+        response = self._request(f'{API_BASE}/2/files/list_folder', json_body=payload)
+        while True:
+            result = response.json()
+            for entry in result.get('entries', []):
+                yield entry
+            if not result.get('has_more'):
+                return
+            response = self._request(f'{API_BASE}/2/files/list_folder/continue',
+                                     json_body={'cursor': result['cursor']})
+
+    def get_current_account(self):
+        """Account info, including which namespace this token's paths resolve in."""
+        return self._request(f'{API_BASE}/2/users/get_current_account').json()
+
+    def get_metadata(self, path):
+        """Return the entry dict for `path`, or None when it does not exist."""
+        try:
+            response = self._request(f'{API_BASE}/2/files/get_metadata',
+                                     json_body={'path': _normalize_path(path)})
+        except DropboxError as e:
+            if e.status_code == 409 and 'not_found' in e.summary:
+                return None
+            raise
+        return response.json()
+
+    def download(self, path):
+        """Download a file's bytes."""
+        response = self._request(
+            f'{CONTENT_BASE}/2/files/download',
+            headers={'Dropbox-API-Arg': json.dumps({'path': _normalize_path(path)})},
+        )
+        return response.content
+
+    def upload(self, path, data, rev=None):
+        """Upload bytes to `path`.
+
+        With `rev`, the write only succeeds if the remote file is still at that
+        revision; without one it only succeeds if the file does not exist yet.
+        Either way a concurrent writer raises DropboxConflict rather than being
+        silently overwritten.
+        """
+        mode = {'.tag': 'update', 'update': rev} if rev else 'add'
+        arg = {
+            'path': _normalize_path(path),
+            'mode': mode,
+            'autorename': False,
+            'mute': True,
+            'strict_conflict': True,
+        }
+        response = self._request(
+            f'{CONTENT_BASE}/2/files/upload',
+            headers={
+                'Dropbox-API-Arg': json.dumps(arg),
+                'Content-Type': 'application/octet-stream',
+            },
+            data=data,
+        )
+        return response.json()
+
+
+def team_namespace_id(account):
+    """The namespace to address, when the token's home is not the team root.
+
+    Members of a Dropbox team see two spaces: their personal home and the team
+    space. Paths resolve against home unless a path root is set, so a folder in
+    the team space is simply invisible without this.
+    """
+    root_info = account.get('root_info') or {}
+    root = root_info.get('root_namespace_id')
+    home = root_info.get('home_namespace_id')
+    return root if root and root != home else None
+
+
+def _normalize_path(path):
+    """Dropbox wants '' for the root and a leading slash everywhere else."""
+    if not path or path == '/':
+        return ''
+    return path if path.startswith('/') else '/' + path
+
+
+def _safe_json(response):
+    try:
+        return response.json()
+    except ValueError:
+        return {'error_summary': response.text[:500]}
+
+
+def _retry_after(response, body, attempt):
+    header = response.headers.get('Retry-After')
+    if header and header.isdigit():
+        return int(header)
+    if isinstance(body, dict):
+        error = body.get('error', {})
+        if isinstance(error, dict) and 'retry_after' in error:
+            return int(error['retry_after'])
+    return 2 ** attempt
+
+
+def authorize_url(app_key):
+    """URL for the one-time consent step (offline access → refresh token)."""
+    from urllib.parse import urlencode
+    params = {
+        'client_id': app_key,
+        'response_type': 'code',
+        'token_access_type': 'offline',
+        'scope': SCOPES,
+    }
+    return 'https://www.dropbox.com/oauth2/authorize?' + urlencode(params)
+
+
+def exchange_code(app_key, app_secret, code):
+    """Exchange an authorization code for tokens (used by the setup script)."""
+    response = requests.post(
+        OAUTH_TOKEN_URL,
+        data={'code': code, 'grant_type': 'authorization_code'},
+        auth=(app_key, app_secret),
+        timeout=DEFAULT_TIMEOUT,
+    )
+    if response.status_code != 200:
+        raise DropboxError(f'Code exchange failed: {response.status_code} {response.text}',
+                           response.status_code)
+    return response.json()
+
+
+def basic_auth_header(app_key, app_secret):
+    """Basic-auth header value, exposed for tests and debugging."""
+    raw = f'{app_key}:{app_secret}'.encode()
+    return 'Basic ' + base64.b64encode(raw).decode()

--- a/functions/dropbox_ingest/images.py
+++ b/functions/dropbox_ingest/images.py
@@ -1,0 +1,115 @@
+"""Aspect-ratio validation and cropping for scanned pages.
+
+Scanned pages are expected at the same 0.53:1 (width:height) ratio the live
+scanner enforces (see the `checkDimensions` ratio check in the screenshots app).
+Anything within tolerance is centre-cropped to exactly that ratio; anything
+further off is rejected rather than distorted.
+"""
+
+from io import BytesIO
+
+from PIL import Image, ImageOps
+
+TARGET_RATIO = 0.53          # width / height
+RATIO_TOLERANCE = 0.10       # (w/h)/TARGET_RATIO must land within 1 ± tolerance
+MIN_SIDE = 300               # px; smaller than this is a thumbnail, not a scan
+MAX_BYTES = 30 * 1024 * 1024
+MAX_PIXELS = 40_000_000      # decoded RGB ~120MB; several of these decode at once
+MAX_SIZE = (2120, 4000)      # 2x the app's 1060x2000 page canvas
+JPEG_QUALITY = 85
+
+
+class ImageRejected(Exception):
+    """The image is not a usable page scan — a terminal verdict.
+
+    Only raised for properties of the image itself, never for transient trouble
+    (a truncated download, running out of memory): those must stay retryable, so
+    they propagate and are recorded as failures instead of skips.
+    """
+
+    def __init__(self, reason):
+        super().__init__(reason)
+        self.reason = reason
+
+
+def ratio_deviation(width, height, ratio=TARGET_RATIO):
+    """How far `width/height` is from the target, as a multiplier of it."""
+    return (width / height) / ratio
+
+
+def crop_to_ratio(image, ratio=TARGET_RATIO):
+    """Centre-crop `image` to exactly `ratio` (width/height)."""
+    width, height = image.size
+    if width / height > ratio:
+        new_width = int(round(height * ratio))
+        left = (width - new_width) // 2
+        return image.crop((left, 0, left + new_width, height))
+    new_height = int(round(width / ratio))
+    upper = (height - new_height) // 2
+    return image.crop((0, upper, width, upper + new_height))
+
+
+def prepare_image(data, *, ratio=TARGET_RATIO, tolerance=RATIO_TOLERANCE,
+                  rotate_landscape='off', min_side=MIN_SIDE, max_bytes=MAX_BYTES,
+                  max_pixels=MAX_PIXELS, max_size=MAX_SIZE, quality=JPEG_QUALITY):
+    """Validate, crop and re-encode a scan for upload.
+
+    Returns `(jpeg_bytes, info)`; raises ImageRejected when the image is not a
+    page scan at the expected proportions.
+    """
+    if len(data) > max_bytes:
+        raise ImageRejected(f'file too large ({len(data)} bytes > {max_bytes})')
+
+    try:
+        image = Image.open(BytesIO(data))
+    except (OSError, ValueError) as e:
+        raise ImageRejected(f'unreadable image ({e})')
+
+    pixels = image.size[0] * image.size[1]
+    if pixels > max_pixels:
+        raise ImageRejected(f'too many pixels ({pixels} > {max_pixels})')
+
+    try:
+        image.load()
+    except (OSError, ValueError) as e:
+        raise ImageRejected(f'unreadable image ({e})')
+
+    image = ImageOps.exif_transpose(image)
+    image = image.convert('RGB')
+    width, height = image.size
+
+    if min(width, height) < min_side:
+        raise ImageRejected(f'too small ({width}x{height}, min side {min_side})')
+
+    rotated = False
+    if not _within(ratio_deviation(width, height, ratio), tolerance):
+        # Optionally rescue landscape scans, but only when the operator has told
+        # us which way the scanner lays pages down — the direction is otherwise
+        # unknowable and a wrong guess uploads upside-down pages.
+        if rotate_landscape in ('cw', 'ccw') and _within(ratio_deviation(height, width, ratio), tolerance):
+            image = image.rotate(-90 if rotate_landscape == 'cw' else 90, expand=True)
+            width, height = image.size
+            rotated = True
+        else:
+            deviation = ratio_deviation(width, height, ratio)
+            raise ImageRejected(
+                f'aspect ratio {width / height:.3f} is {deviation:.2f}x the target '
+                f'{ratio} (allowed {1 - tolerance:.2f}-{1 + tolerance:.2f}x)')
+
+    cropped = crop_to_ratio(image, ratio)
+    cropped.thumbnail(max_size, Image.Resampling.LANCZOS)
+
+    out = BytesIO()
+    cropped.save(out, format='jpeg', quality=quality, optimize=True, progressive=True)
+    info = dict(
+        original_size=[width, height],
+        cropped_size=list(cropped.size),
+        rotated=rotated,
+        bytes=out.tell(),
+    )
+    out.seek(0)
+    return out.getvalue(), info
+
+
+def _within(deviation, tolerance):
+    return 1 - tolerance <= deviation <= 1 + tolerance

--- a/functions/dropbox_ingest/lock.py
+++ b/functions/dropbox_ingest/lock.py
@@ -1,0 +1,49 @@
+"""A best-effort Firestore lock, so two scheduled runs never ingest at once.
+
+Two concurrent runs would both see the same "new" files and upload them twice
+before either writes its state file. The lock is advisory and self-expiring: if
+a run dies the lease simply times out.
+"""
+
+import datetime
+import uuid
+
+LOCK_COLLECTION = 'chronomaps_global'
+LOCK_DOCUMENT = 'dropbox_ingest_lock'
+DEFAULT_TTL_SECONDS = 1800
+
+
+def _now():
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+def acquire(ttl_seconds=DEFAULT_TTL_SECONDS, db=None):
+    """Take the lease. Returns a holder token, or None if someone else holds it."""
+    from firebase_admin import firestore
+    db = db or firestore.client()
+    reference = db.collection(LOCK_COLLECTION).document(LOCK_DOCUMENT)
+    holder = str(uuid.uuid4())
+    expires_at = (_now() + datetime.timedelta(seconds=ttl_seconds)).isoformat()
+
+    transaction = db.transaction()
+
+    @firestore.transactional
+    def attempt(tx):
+        snapshot = reference.get(transaction=tx).to_dict() or {}
+        current = snapshot.get('expires_at')
+        if current and current > _now().isoformat():
+            return None
+        tx.set(reference, {'holder': holder, 'expires_at': expires_at, 'acquired_at': _now().isoformat()})
+        return holder
+
+    return attempt(transaction)
+
+
+def release(holder, db=None):
+    """Release the lease, but only if we still hold it."""
+    from firebase_admin import firestore
+    db = db or firestore.client()
+    reference = db.collection(LOCK_COLLECTION).document(LOCK_DOCUMENT)
+    snapshot = reference.get().to_dict() or {}
+    if snapshot.get('holder') == holder:
+        reference.set({'holder': None, 'expires_at': None, 'released_at': _now().isoformat()})

--- a/functions/main.py
+++ b/functions/main.py
@@ -234,3 +234,44 @@ def cluster_its_time(event: scheduler_fn.ScheduledEvent) -> None:
     response = '\n'.join(generate())
     return https_fn.Response(response, status=200, mimetype='plain/text')
 
+
+# Only actual credentials live in Secret Manager; the rest (root path, cutoff,
+# namespace) is non-sensitive configuration and ships in functions/.env.chronomaps3,
+# so a deploy from CI does not depend on secrets that must be created by hand.
+DROPBOX_INGEST_SECRETS = [
+    'SERVICE_ACCOUNT_JSON', 'CHRONOMAPS_API_URL',
+    'DROPBOX_APP_KEY', 'DROPBOX_APP_SECRET', 'DROPBOX_REFRESH_TOKEN',
+]
+
+def _run_dropbox_ingest(dry_run=False, only_folder=None):
+    """Run the ingest under the shared lock, printing each status line."""
+    from dropbox_ingest import run_ingest as run_ingest_fn
+    from dropbox_ingest import lock as ingest_lock
+
+    holder = ingest_lock.acquire()
+    if not holder:
+        bit = dict(action='skipped', reason='another dropbox ingest run holds the lock')
+        print(json.dumps(bit, ensure_ascii=False))
+        return [bit]
+    bits = []
+    try:
+        for bit in run_ingest_fn(dry_run=dry_run, only_folder=only_folder):
+            print(json.dumps(bit, ensure_ascii=False))
+            bits.append(bit)
+    finally:
+        ingest_lock.release(holder)
+    return bits
+
+@scheduler_fn.on_schedule(region='europe-west1', schedule="every 5 minutes", secrets=DROPBOX_INGEST_SECRETS, memory=options.MemoryOption.GB_2, timeout_sec=1800)
+def dropbox_ingest_scheduled(event: scheduler_fn.ScheduledEvent) -> None:
+    print("STARTING dropbox ingest")
+    _run_dropbox_ingest()
+
+@https_fn.on_request(region='europe-west4', cors=options.CorsOptions(cors_origins="*", cors_methods=["post"]), secrets=DROPBOX_INGEST_SECRETS, memory=options.MemoryOption.GB_2, timeout_sec=1800)
+def dropbox_ingest(req: https_fn.Request) -> https_fn.Response:
+    if not verify_firebase_admin(req):
+        return https_fn.Response("Unauthorized", status=401)
+    dry_run = req.args.get('dry_run', 'false').lower() == 'true'
+    only_folder = req.args.get('folder')
+    bits = _run_dropbox_ingest(dry_run=dry_run, only_folder=only_folder)
+    return https_fn.Response(json.dumps(bits, ensure_ascii=False), status=200, mimetype='application/json')

--- a/functions/tests/test_dropbox_ingest.py
+++ b/functions/tests/test_dropbox_ingest.py
@@ -1,0 +1,828 @@
+"""
+Tests for the dropbox_ingest module.
+
+Covers the pure pieces (credentials parsing, state merging, batching, cropping)
+and the folder flow end to end against a fake Dropbox client.
+"""
+
+import datetime
+import json
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+from PIL import Image
+
+from dropbox_ingest import (
+    ConfigurationError, FolderConfig, Settings, assign_batches, batches_from,
+    derive_handler_url, empty_state, entry_key, find_config_entry, folder_created_at,
+    is_known, merge_batches, merge_states, parse_credentials, process_folder, read_state,
+    run_ingest, scan_time, upload_scan, write_state, MAX_FILE_ATTEMPTS,
+)
+from dropbox_ingest.dropbox_api import (
+    DropboxClient, DropboxConflict, DropboxError, team_namespace_id,
+)
+from dropbox_ingest.images import ImageRejected, crop_to_ratio, prepare_image
+
+NOW = datetime.datetime(2026, 8, 25, 12, 0, 0, tzinfo=datetime.timezone.utc)
+CUTOFF = datetime.datetime(2026, 8, 20, 0, 0, 0, tzinfo=datetime.timezone.utc)
+
+
+# -- helpers ----------------------------------------------------------------
+
+def make_settings(**overrides):
+    defaults = dict(
+        app_key='key', app_secret='secret', refresh_token='refresh',
+        root_path='/archive', folder_cutoff=CUTOFF, settle_seconds=180,
+        chronomaps_api_url='https://api.example.com',
+        screenshot_handler_url='https://handler.example.com',
+    )
+    defaults.update(overrides)
+    return Settings(**defaults)
+
+
+def batch(author_id, first, last=None):
+    return {'author_id': author_id, 'first_scanned_at': first, 'last_scanned_at': last or first}
+
+
+def file_entry(path, *, client_modified='2026-08-25T10:00:00Z', server_modified=None,
+               content_hash=None, size=1000):
+    name = path.rsplit('/', 1)[-1]
+    return {
+        '.tag': 'file', 'name': name, 'path_display': path, 'path_lower': path.lower(),
+        'client_modified': client_modified, 'server_modified': server_modified or client_modified,
+        'content_hash': content_hash or f'hash-{name}', 'size': size, 'rev': f'rev-{name}',
+    }
+
+
+def folder_entry(path):
+    name = path.rsplit('/', 1)[-1]
+    return {'.tag': 'folder', 'name': name, 'path_display': path, 'path_lower': path.lower()}
+
+
+def image_bytes(width, height, fmt='JPEG'):
+    buffer = BytesIO()
+    Image.new('RGB', (width, height), (200, 180, 160)).save(buffer, format=fmt)
+    return buffer.getvalue()
+
+
+class FakeDropbox:
+    """In-memory stand-in for DropboxClient."""
+
+    def __init__(self, entries_by_folder, files=None):
+        self.entries_by_folder = entries_by_folder
+        self.files = files or {}
+        self.uploads = []
+        self.rev_counter = 0
+
+    def list_folder(self, path, recursive=False):
+        return iter(self.entries_by_folder.get(path, []))
+
+    def get_metadata(self, path):
+        if path in self.files:
+            return {'.tag': 'file', 'path_display': path, 'rev': self.files[path][1]}
+        return None
+
+    def download(self, path):
+        if path not in self.files:
+            raise AssertionError(f'unexpected download of {path}')
+        return self.files[path][0]
+
+    def upload(self, path, data, rev=None):
+        existing = self.files.get(path)
+        if existing and (rev is None or existing[1] != rev):
+            # Mirrors Dropbox: `add` fails if the file exists, `update` fails on a stale rev.
+            raise DropboxConflict('rev mismatch', 409, {})
+        self.rev_counter += 1
+        new_rev = f'rev{self.rev_counter}'
+        self.files[path] = (data, new_rev)
+        self.uploads.append((path, data, rev))
+        return {'rev': new_rev}
+
+
+# -- credentials ------------------------------------------------------------
+
+class TestParseCredentials:
+    def test_key_value_lines(self):
+        config = parse_credentials('workspace: ws-1\napi_key: key-1\n')
+        assert config.workspace == 'ws-1'
+        assert config.api_key == 'key-1'
+        assert config.enabled is True
+        assert config.ignore_cutoff is False
+
+    def test_json(self):
+        config = parse_credentials(json.dumps({'workspace': 'ws-2', 'api_key': 'key-2'}))
+        assert (config.workspace, config.api_key) == ('ws-2', 'key-2')
+
+    def test_comments_equals_and_quotes(self):
+        config = parse_credentials('# a comment\nworkspace = "ws-3"\nAPI_KEY = key-3\n\n')
+        assert (config.workspace, config.api_key) == ('ws-3', 'key-3')
+
+    def test_optional_overrides(self):
+        config = parse_credentials(
+            'workspace: ws\napi_key: key\nenabled: false\nignore_cutoff: yes\n'
+            'batch_gap_seconds: 300\nratio: 0.6\nratio_tolerance: 0.2\n'
+            'max_uploads_per_run: 5\ntime_source: server\nrotate_landscape: cw\n')
+        assert config.enabled is False
+        assert config.ignore_cutoff is True
+        assert config.batch_gap_seconds == 300
+        assert config.ratio == 0.6
+        assert config.ratio_tolerance == 0.2
+        assert config.max_uploads_per_run == 5
+        assert config.time_source == 'server'
+        assert config.rotate_landscape == 'cw'
+
+    def test_missing_fields_rejected(self):
+        with pytest.raises(ConfigurationError):
+            parse_credentials('workspace: ws-only\n')
+
+    def test_unparsable_json_rejected(self):
+        with pytest.raises(ConfigurationError):
+            parse_credentials('{not json')
+
+    def test_non_numeric_override_is_a_folder_problem_not_a_crash(self):
+        """A decimal comma must fail this folder, not the whole scheduled run."""
+        with pytest.raises(ConfigurationError):
+            parse_credentials('workspace: ws\napi_key: k\nratio: 0,53\n')
+
+
+class TestDeriveHandlerUrl:
+    def test_cloud_run_form(self):
+        assert derive_handler_url('https://chronomaps-api-qjzuw7ypfq-ez.a.run.app/') == \
+            'https://screenshot-handler-qjzuw7ypfq-ez.a.run.app'
+
+    def test_cloud_functions_form(self):
+        assert derive_handler_url('https://europe-west4-chronomaps3.cloudfunctions.net/chronomaps_api') == \
+            'https://europe-west4-chronomaps3.cloudfunctions.net/screenshot_handler'
+
+    def test_unrecognised_form_is_an_error_not_a_silent_no_op(self):
+        with pytest.raises(ConfigurationError):
+            derive_handler_url('https://api.internal.example.com/v2')
+
+
+class TestDropboxClientTransport:
+    """Network trouble must arrive as DropboxError, not as a raw requests error."""
+
+    def _client(self, session):
+        client = DropboxClient('key', 'secret', 'refresh', session=session)
+        client._token, client._token_expires_at = 'token', 2 ** 40
+        return client
+
+    def test_connection_errors_are_retried_then_wrapped(self, monkeypatch):
+        import requests as requests_module
+        monkeypatch.setattr('dropbox_ingest.dropbox_api.time.sleep', lambda _s: None)
+        session = Mock()
+        session.post.side_effect = requests_module.ConnectionError('reset by peer')
+
+        with pytest.raises(DropboxError) as excinfo:
+            self._client(session).get_metadata('/archive/ws/a.jpg')
+
+        assert 'ConnectionError' in str(excinfo.value)
+        assert session.post.call_count > 1, 'transient errors are retried'
+
+    def test_recovers_when_a_retry_succeeds(self, monkeypatch):
+        import requests as requests_module
+        monkeypatch.setattr('dropbox_ingest.dropbox_api.time.sleep', lambda _s: None)
+        ok = Mock(status_code=200)
+        ok.json.return_value = {'rev': 'r1'}
+        session = Mock()
+        session.post.side_effect = [requests_module.ReadTimeout('slow'), ok]
+
+        assert self._client(session).get_metadata('/archive/ws/a.jpg') == {'rev': 'r1'}
+
+    def test_token_is_refreshed_once_for_concurrent_workers(self):
+        import threading
+        token_response = Mock(status_code=200)
+        token_response.json.return_value = {'access_token': 'fresh', 'expires_in': 14400}
+        session = Mock()
+        session.post.return_value = token_response
+
+        client = DropboxClient('key', 'secret', 'refresh', session=session)
+        threads = [threading.Thread(target=client.access_token) for _ in range(4)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert session.post.call_count == 1, 'a locked refresh, not one per worker'
+
+    def test_team_namespace_detected_only_when_home_differs_from_root(self):
+        personal = {'root_info': {'root_namespace_id': '12345', 'home_namespace_id': '12345'}}
+        team = {'root_info': {'root_namespace_id': '99999', 'home_namespace_id': '12345'}}
+        assert team_namespace_id(personal) is None
+        assert team_namespace_id(team) == '99999'
+        assert team_namespace_id({}) is None
+
+    def test_threads_get_their_own_session(self):
+        import threading
+        client = DropboxClient('key', 'secret', 'refresh')
+        sessions = []
+        threads = [threading.Thread(target=lambda: sessions.append(client.session)) for _ in range(2)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+        assert sessions[0] is not sessions[1]
+
+
+# -- listing / eligibility --------------------------------------------------
+
+class TestFolderEligibility:
+    def test_config_file_must_be_at_folder_root(self):
+        entries = [file_entry('/archive/ws/sub/chronomaps.config'), file_entry('/archive/ws/a.jpg')]
+        assert find_config_entry(entries, '/archive/ws') is None
+
+    def test_config_file_found_by_any_accepted_name(self):
+        for name in ('chronomaps.config', '.chronomaps.config', 'chronomaps.txt'):
+            entries = [file_entry(f'/archive/ws/{name}')]
+            assert find_config_entry(entries, '/archive/ws')['name'] == name
+
+    def test_folder_created_at_is_oldest_server_modified(self):
+        entries = [
+            folder_entry('/archive/ws/sub'),
+            file_entry('/archive/ws/b.jpg', server_modified='2026-08-22T09:00:00Z'),
+            file_entry('/archive/ws/a.jpg', server_modified='2026-08-21T09:00:00Z'),
+        ]
+        assert folder_created_at(entries) == datetime.datetime(2026, 8, 21, 9, 0, tzinfo=datetime.timezone.utc)
+
+    def test_folder_created_at_none_when_empty(self):
+        assert folder_created_at([folder_entry('/archive/ws/sub')]) is None
+
+
+class TestIsKnown:
+    def test_uploaded_and_skipped_are_known(self):
+        state = empty_state('ws')
+        state['files']['h1'] = {'item_id': 'i1'}
+        state['skipped']['h2'] = {'reason': 'ratio'}
+        assert is_known(state, 'h1') and is_known(state, 'h2')
+
+    def test_failures_retry_until_quarantined(self):
+        state = empty_state('ws')
+        state['failed']['h3'] = {'attempts': MAX_FILE_ATTEMPTS - 1}
+        assert not is_known(state, 'h3')
+        state['failed']['h3'] = {'attempts': MAX_FILE_ATTEMPTS}
+        assert is_known(state, 'h3')
+
+
+# -- batching ---------------------------------------------------------------
+
+class TestAssignBatches:
+    def test_close_scans_share_an_author(self):
+        entries = [
+            file_entry('/ws/1.jpg', client_modified='2026-08-25T10:00:00Z'),
+            file_entry('/ws/2.jpg', client_modified='2026-08-25T10:00:30Z'),
+            file_entry('/ws/3.jpg', client_modified='2026-08-25T10:01:00Z'),
+        ]
+        assignments, _ = assign_batches(entries, None, 120)
+        authors = {a[2] for a in assignments}
+        assert len(authors) == 1
+
+    def test_gap_starts_a_new_batch(self):
+        entries = [
+            file_entry('/ws/1.jpg', client_modified='2026-08-25T10:00:00Z'),
+            file_entry('/ws/2.jpg', client_modified='2026-08-25T10:05:00Z'),
+        ]
+        assignments, batches = assign_batches(entries, None, 120)
+        assert assignments[0][2] != assignments[1][2]
+        assert [b['author_id'] for b in batches] == [assignments[0][2], assignments[1][2]]
+        assert batches[-1]['last_scanned_at'] == '2026-08-25T10:05:00Z'
+
+    def test_boundary_is_inclusive(self):
+        entries = [
+            file_entry('/ws/1.jpg', client_modified='2026-08-25T10:00:00Z'),
+            file_entry('/ws/2.jpg', client_modified='2026-08-25T10:02:00Z'),
+        ]
+        assignments, _ = assign_batches(entries, None, 120)
+        assert assignments[0][2] == assignments[1][2]
+
+    def test_late_arrival_joins_previous_run_batch(self):
+        """A page that syncs late still lands in the batch it was scanned with."""
+        history = [batch('author-from-earlier-run', '2026-08-25T09:59:00Z', '2026-08-25T10:00:00Z')]
+        entries = [file_entry('/ws/late.jpg', client_modified='2026-08-25T10:01:00Z',
+                              server_modified='2026-08-25T11:30:00Z')]
+        assignments, _ = assign_batches(entries, history, 120)
+        assert assignments[0][2] == 'author-from-earlier-run'
+
+    def test_old_scan_arriving_late_starts_its_own_batch(self):
+        history = [batch('current-batch', '2026-08-25T09:58:00Z', '2026-08-25T10:00:00Z')]
+        entries = [file_entry('/ws/old.jpg', client_modified='2026-08-22T09:00:00Z',
+                              server_modified='2026-08-25T11:00:00Z')]
+        assignments, _ = assign_batches(entries, history, 120)
+        assert assignments[0][2] != 'current-batch'
+
+    def test_late_page_rejoins_its_own_batch_not_the_newest_one(self):
+        """With two batches already known, a straggler must match the right one."""
+        history = [batch('author-a', '2026-08-25T10:00:00Z', '2026-08-25T10:02:00Z'),
+                   batch('author-b', '2026-08-25T10:30:00Z', '2026-08-25T10:32:00Z')]
+        entries = [file_entry('/ws/straggler.jpg', client_modified='2026-08-25T10:03:00Z',
+                              server_modified='2026-08-25T11:40:00Z')]
+        assignments, _ = assign_batches(entries, history, 120)
+        assert assignments[0][2] == 'author-a'
+
+    def test_batch_history_is_capped(self):
+        entries = [file_entry(f'/ws/{i}.jpg', client_modified=f'2026-08-25T{10 + i:02d}:00:00Z')
+                   for i in range(13)]
+        _assignments, batches = assign_batches(entries, None, 120)
+        assert len(batches) == 10, 'only the most recent batches stay joinable'
+
+    def test_batches_from_summarises_ranges(self):
+        entries = [file_entry('/ws/1.jpg', client_modified='2026-08-25T10:00:00Z'),
+                   file_entry('/ws/2.jpg', client_modified='2026-08-25T10:01:00Z')]
+        assignments, _ = assign_batches(entries, None, 120)
+        summary = batches_from(assignments)
+        assert summary == [{'author_id': assignments[0][2],
+                            'first_scanned_at': '2026-08-25T10:00:00Z',
+                            'last_scanned_at': '2026-08-25T10:01:00Z'}]
+
+    def test_sorted_by_scan_time_not_sync_time(self):
+        entries = [
+            file_entry('/ws/second.jpg', client_modified='2026-08-25T10:01:00Z',
+                       server_modified='2026-08-25T10:01:10Z'),
+            file_entry('/ws/first.jpg', client_modified='2026-08-25T10:00:00Z',
+                       server_modified='2026-08-25T11:00:00Z'),
+        ]
+        assignments, _ = assign_batches(entries, None, 120)
+        assert [a[0]['name'] for a in assignments] == ['first.jpg', 'second.jpg']
+
+    def test_time_source_override(self):
+        entry = file_entry('/ws/a.jpg', client_modified='2026-08-25T10:00:00Z',
+                           server_modified='2026-08-25T11:00:00Z')
+        assert scan_time(entry).hour == 10
+        assert scan_time(entry, 'server').hour == 11
+
+
+# -- state ------------------------------------------------------------------
+
+class TestState:
+    def test_read_state_missing_file(self):
+        client = FakeDropbox({}, {})
+        state, rev = read_state(client, '/archive/ws', 'ws-1')
+        assert rev is None and state['files'] == {} and state['workspace'] == 'ws-1'
+
+    def test_read_state_rejects_corrupt_file(self):
+        client = FakeDropbox({}, {'/archive/ws/chronomaps.state.json': (b'not json', 'rev1')})
+        with pytest.raises(ConfigurationError):
+            read_state(client, '/archive/ws', 'ws-1')
+
+    def test_merge_keeps_both_sides_records_and_batches(self):
+        remote = {'files': {'a': {'item_id': 'remote'}}, 'skipped': {}, 'failed': {},
+                  'workspace': 'ws', 'recent_batches': [batch('r', '2026-08-25T09:00:00Z')]}
+        local = {'files': {'b': {'item_id': 'local'}}, 'skipped': {}, 'failed': {},
+                 'workspace': 'ws', 'recent_batches': [batch('l', '2026-08-25T10:00:00Z')]}
+        merged = merge_states(remote, local)
+        assert set(merged['files']) == {'a', 'b'}
+        assert [b['author_id'] for b in merged['recent_batches']] == ['r', 'l']
+
+    def test_merge_batches_widens_a_known_batch(self):
+        merged = merge_batches([batch('a', '2026-08-25T10:00:00Z', '2026-08-25T10:01:00Z')],
+                               [batch('a', '2026-08-25T09:59:00Z', '2026-08-25T10:05:00Z')])
+        assert merged == [batch('a', '2026-08-25T09:59:00Z', '2026-08-25T10:05:00Z')]
+
+    def test_legacy_last_batch_state_is_migrated(self):
+        legacy = json.dumps({'version': 1, 'workspace': 'ws', 'files': {}, 'skipped': {}, 'failed': {},
+                             'last_batch': {'author_id': 'old', 'last_scanned_at': '2026-08-25T10:00:00Z'}})
+        client = FakeDropbox({}, {'/archive/ws/chronomaps.state.json': (legacy.encode(), 'rev1')})
+        state, _rev = read_state(client, '/archive/ws', 'ws')
+        assert state['recent_batches'] == [batch('old', '2026-08-25T10:00:00Z')]
+        assert 'last_batch' not in state
+
+    def test_first_write_merges_with_a_concurrent_creation(self):
+        """Two runs creating the state file at once must not lose each other's records."""
+        concurrent = json.dumps({'version': 1, 'workspace': 'ws', 'files': {'theirs': {'item_id': 'x'}},
+                                 'skipped': {}, 'failed': {}, 'last_batch': None}).encode()
+        client = FakeDropbox({}, {'/archive/ws/chronomaps.state.json': (concurrent, 'their-rev')})
+        state = empty_state('ws')
+        state['files']['ours'] = {'item_id': 'y'}
+
+        written, _ = write_state(client, '/archive/ws', state, None)
+
+        assert set(written['files']) == {'theirs', 'ours'}
+
+    def test_write_state_merges_on_conflict(self):
+        """A concurrent writer's records survive our write."""
+        concurrent = json.dumps({'version': 1, 'workspace': 'ws', 'files': {'theirs': {'item_id': 'x'}},
+                                 'skipped': {}, 'failed': {}, 'last_batch': None}).encode()
+        client = FakeDropbox({}, {'/archive/ws/chronomaps.state.json': (concurrent, 'newer-rev')})
+        state = empty_state('ws')
+        state['files']['ours'] = {'item_id': 'y'}
+
+        written, rev = write_state(client, '/archive/ws', state, 'stale-rev')
+
+        assert set(written['files']) == {'theirs', 'ours'}
+        assert rev is not None
+
+
+# -- image preparation ------------------------------------------------------
+
+class TestPrepareImage:
+    def test_exact_ratio_passes_through(self):
+        data, info = prepare_image(image_bytes(530, 1000))
+        assert Image.open(BytesIO(data)).size == (530, 1000)
+        assert info['rotated'] is False
+
+    def test_within_tolerance_is_cropped_to_target(self):
+        data, _ = prepare_image(image_bytes(560, 1000))  # 0.56 -> 1.06x target
+        width, height = Image.open(BytesIO(data)).size
+        assert width / height == pytest.approx(0.53, abs=0.005)
+
+    def test_outside_tolerance_is_rejected(self):
+        with pytest.raises(ImageRejected) as excinfo:
+            prepare_image(image_bytes(750, 1000))  # 0.75 -> 1.42x target
+        assert 'aspect ratio' in excinfo.value.reason
+
+    def test_tolerance_boundaries(self):
+        prepare_image(image_bytes(583, 1000))  # 1.10x — allowed
+        with pytest.raises(ImageRejected):
+            prepare_image(image_bytes(590, 1000))  # 1.11x — rejected
+
+    def test_tiny_image_rejected(self):
+        with pytest.raises(ImageRejected) as excinfo:
+            prepare_image(image_bytes(106, 200))
+        assert 'too small' in excinfo.value.reason
+
+    def test_unreadable_rejected(self):
+        with pytest.raises(ImageRejected):
+            prepare_image(b'this is not an image')
+
+    def test_oversized_file_rejected(self):
+        with pytest.raises(ImageRejected):
+            prepare_image(image_bytes(530, 1000), max_bytes=10)
+
+    def test_landscape_rejected_by_default_rotated_when_configured(self):
+        landscape = image_bytes(1000, 530)
+        with pytest.raises(ImageRejected):
+            prepare_image(landscape)
+        data, info = prepare_image(landscape, rotate_landscape='cw')
+        width, height = Image.open(BytesIO(data)).size
+        assert info['rotated'] is True and width < height
+
+    def test_large_scan_is_downscaled(self):
+        data, _ = prepare_image(image_bytes(2650, 5000))
+        width, height = Image.open(BytesIO(data)).size
+        assert (width, height) <= (2120, 4000)
+        assert width / height == pytest.approx(0.53, abs=0.005)
+
+    def test_huge_image_rejected_before_decoding(self):
+        """Four workers decoding at once must not be able to exhaust the container."""
+        with pytest.raises(ImageRejected) as excinfo:
+            prepare_image(image_bytes(4000, 7547), max_pixels=1_000_000)
+        assert 'too many pixels' in excinfo.value.reason
+
+    def test_crop_to_ratio_centres(self):
+        cropped = crop_to_ratio(Image.new('RGB', (1000, 1000)))
+        assert cropped.size == (530, 1000)
+
+
+# -- upload -----------------------------------------------------------------
+
+class TestUploadScan:
+    def _session(self, post_payload=None, post_status=200, put_status=200):
+        session = Mock()
+        post_response = Mock(status_code=post_status, text='')
+        post_response.json.return_value = post_payload or {'item_id': 'item-1', 'item_key': 'key-1'}
+        session.post.return_value = post_response
+        session.put.return_value = Mock(status_code=put_status, text='')
+        return session
+
+    def test_posts_in_automatic_mode_and_puts_author_id(self):
+        session = self._session()
+        config = FolderConfig(workspace='ws-1', api_key='api-key')
+        item_id, item_key, metadata_error = upload_scan(
+            make_settings(), config, b'jpeg', 'page.jpg', 'author-9',
+            {'source': 'dropbox'}, session=session)
+
+        assert (item_id, item_key, metadata_error) == ('item-1', 'key-1', None)
+        post_params = session.post.call_args.kwargs['params']
+        assert post_params == {'workspace': 'ws-1', 'api_key': 'api-key', 'automatic': 'true'}
+        assert 'image' in session.post.call_args.kwargs['files']
+
+        put_args = session.put.call_args
+        assert put_args.args[0] == 'https://api.example.com/ws-1/item-1'
+        assert put_args.kwargs['json']['author_id'] == 'author-9'
+        assert put_args.kwargs['json']['source'] == 'dropbox'
+        assert put_args.kwargs['headers'] == {'Authorization': 'api-key'}
+        assert put_args.kwargs['params'] == {'item-key': 'key-1'}
+
+    def test_metadata_is_not_sent_to_the_vision_prompt(self):
+        """Bookkeeping fields must not ride along in the handler's `metadata` form field."""
+        session = self._session()
+        upload_scan(make_settings(), FolderConfig(workspace='ws', api_key='k'), b'jpeg', 'p.jpg',
+                    'author', {'source': 'dropbox'}, session=session)
+        assert 'data' not in session.post.call_args.kwargs
+        assert set(session.post.call_args.kwargs['files']) == {'image'}
+
+    def test_handler_failure_raises(self):
+        session = self._session(post_status=403)
+        with pytest.raises(RuntimeError):
+            upload_scan(make_settings(), FolderConfig(workspace='ws', api_key='k'), b'x', 'p.jpg',
+                        'a', {}, session=session)
+
+    def test_metadata_failure_is_reported_not_raised(self):
+        """The item already exists — raising would make the next run duplicate it."""
+        session = self._session(put_status=500)
+        item_id, _key, metadata_error = upload_scan(
+            make_settings(), FolderConfig(workspace='ws', api_key='k'), b'x', 'p.jpg',
+            'a', {}, session=session)
+        assert item_id == 'item-1'
+        assert 'metadata update returned 500' in metadata_error
+
+
+# -- folder flow ------------------------------------------------------------
+
+class FolderFixture:
+    """A Dropbox folder with a credentials file and a few scans."""
+
+    def __init__(self, files=(), config_text='workspace: ws-1\napi_key: key-1\n',
+                 created='2026-08-24T09:00:00Z', state=None):
+        self.folder = folder_entry('/archive/ws')
+        entries = [file_entry('/archive/ws/chronomaps.config', server_modified=created)]
+        stored = {'/archive/ws/chronomaps.config': (config_text.encode(), 'rev-config')}
+        for entry_spec in files:
+            name, data, client_modified, server_modified = entry_spec[:4]
+            content_hash = entry_spec[4] if len(entry_spec) > 4 else f'hash-{name}'
+            path = f'/archive/ws/{name}'
+            entries.append(file_entry(path, client_modified=client_modified,
+                                      server_modified=server_modified, content_hash=content_hash,
+                                      size=len(data)))
+            stored[path] = (data, f'rev-{name}')
+        if state is not None:
+            stored['/archive/ws/chronomaps.state.json'] = (json.dumps(state).encode(), 'rev-state')
+            entries.append(file_entry('/archive/ws/chronomaps.state.json', server_modified=created))
+        self.client = FakeDropbox({'/archive/ws': entries, '/archive': [self.folder]}, stored)
+
+    def run(self, settings=None, **kwargs):
+        return list(process_folder(self.client, self.folder, settings or make_settings(),
+                                   now=NOW, **kwargs))
+
+    def state(self):
+        return json.loads(self.client.files['/archive/ws/chronomaps.state.json'][0])
+
+
+def upload_session():
+    """A requests-like session that names each item after the file it received.
+
+    Uploads run concurrently, so the response must depend on the request rather
+    than on call order.
+    """
+    session = Mock()
+
+    def post(*args, **kwargs):
+        filename = kwargs['files']['image'][0]
+        response = Mock(status_code=200, text='')
+        response.json.return_value = {'item_id': f'item-{Path(filename).stem}', 'item_key': 'k'}
+        return response
+
+    session.post.side_effect = post
+    session.put.return_value = Mock(status_code=200, text='')
+    return session
+
+
+class TestProcessFolder:
+    def test_folder_without_credentials_is_skipped_untouched(self):
+        client = FakeDropbox({'/archive/ws': [file_entry('/archive/ws/a.jpg')]}, {})
+        results = list(process_folder(client, folder_entry('/archive/ws'), make_settings(), now=NOW))
+        assert results == [{'folder': 'ws', 'action': 'skip-folder', 'reason': 'no credentials file'}]
+        assert client.uploads == []
+
+    def test_folder_created_before_cutoff_is_skipped(self):
+        fixture = FolderFixture(files=[('a.jpg', image_bytes(530, 1000),
+                                        '2026-08-19T10:00:00Z', '2026-08-19T10:00:00Z')],
+                                created='2026-08-19T09:00:00Z')
+        results = fixture.run()
+        assert results[0]['action'] == 'skip-folder'
+        assert 'before cutoff' in results[0]['reason']
+
+    def test_ignore_cutoff_override_backfills_old_folder(self):
+        fixture = FolderFixture(
+            files=[('a.jpg', image_bytes(530, 1000), '2026-08-19T10:00:00Z', '2026-08-19T10:00:00Z')],
+            config_text='workspace: ws-1\napi_key: key-1\nignore_cutoff: true\n',
+            created='2026-08-19T09:00:00Z')
+        results = fixture.run(session=upload_session())
+        assert [r['action'] for r in results if r['action'] == 'uploaded']
+
+    def test_disabled_folder_is_skipped(self):
+        fixture = FolderFixture(config_text='workspace: ws-1\napi_key: key-1\nenabled: false\n')
+        assert fixture.run()[0]['reason'] == 'disabled in credentials file'
+
+    def test_uploads_new_scans_and_records_state(self):
+        fixture = FolderFixture(files=[
+            ('a.jpg', image_bytes(530, 1000), '2026-08-25T10:00:00Z', '2026-08-25T10:00:20Z'),
+            ('b.jpg', image_bytes(530, 1000), '2026-08-25T10:00:40Z', '2026-08-25T10:01:00Z'),
+        ])
+        results = fixture.run(session=upload_session())
+
+        uploaded = [r for r in results if r['action'] == 'uploaded']
+        assert len(uploaded) == 2
+        assert len({r['author_id'] for r in uploaded}) == 1, 'same batch shares an author'
+
+        state = fixture.state()
+        assert set(state['files']) == {'hash-a.jpg', 'hash-b.jpg'}
+        assert state['files']['hash-a.jpg']['item_id'] == 'item-a'  # named after a.jpg
+        assert [b['author_id'] for b in state['recent_batches']] == [uploaded[0]['author_id']]
+
+    def test_already_uploaded_scans_are_not_uploaded_again(self):
+        state = dict(empty_state('ws-1'), files={'hash-a.jpg': {'item_id': 'item-a'}})
+        fixture = FolderFixture(
+            files=[('a.jpg', image_bytes(530, 1000), '2026-08-25T10:00:00Z', '2026-08-25T10:00:20Z')],
+            state=state)
+        session = upload_session()
+        results = fixture.run(session=session)
+        assert results[0]['new'] == 0
+        assert session.post.call_count == 0
+
+    def test_scans_still_syncing_are_deferred(self):
+        fixture = FolderFixture(files=[
+            ('a.jpg', image_bytes(530, 1000), '2026-08-25T11:59:50Z', '2026-08-25T11:59:55Z'),
+        ])
+        results = fixture.run(session=upload_session())
+        assert results[0]['ready'] == 0 and results[0]['syncing'] == 1
+
+    def test_wrong_ratio_is_skipped_and_remembered(self):
+        fixture = FolderFixture(files=[
+            ('wide.jpg', image_bytes(1000, 1000), '2026-08-25T10:00:00Z', '2026-08-25T10:00:20Z'),
+        ])
+        results = fixture.run(session=upload_session())
+        skipped = [r for r in results if r['action'] == 'skip-image']
+        assert len(skipped) == 1 and 'aspect ratio' in skipped[0]['reason']
+        assert 'hash-wide.jpg' in fixture.state()['skipped']
+
+    def test_upload_failure_is_recorded_for_retry(self):
+        fixture = FolderFixture(files=[
+            ('a.jpg', image_bytes(530, 1000), '2026-08-25T10:00:00Z', '2026-08-25T10:00:20Z'),
+        ])
+        session = Mock()
+        session.post.return_value = Mock(status_code=500, text='boom')
+        results = fixture.run(session=session)
+
+        assert [r for r in results if r['action'] == 'error']
+        failed = fixture.state()['failed']['hash-a.jpg']
+        assert failed['attempts'] == 1
+        assert not is_known(fixture.state(), 'hash-a.jpg'), 'retried on the next run'
+
+    def test_separate_batches_get_separate_authors(self):
+        fixture = FolderFixture(files=[
+            ('a.jpg', image_bytes(530, 1000), '2026-08-25T10:00:00Z', '2026-08-25T10:00:20Z'),
+            ('b.jpg', image_bytes(530, 1000), '2026-08-25T10:30:00Z', '2026-08-25T10:30:20Z'),
+        ])
+        results = fixture.run(session=upload_session())
+        authors = {r['author_id'] for r in results if r['action'] == 'uploaded'}
+        assert len(authors) == 2
+
+    def test_max_uploads_per_run_caps_and_defers(self):
+        fixture = FolderFixture(
+            files=[(f'{i}.jpg', image_bytes(530, 1000), f'2026-08-25T10:0{i}:00Z',
+                    f'2026-08-25T10:0{i}:20Z') for i in range(3)],
+            config_text='workspace: ws-1\napi_key: key-1\nmax_uploads_per_run: 2\n')
+        results = fixture.run(session=upload_session())
+        assert [r for r in results if r['action'] == 'capped'][0]['deferred'] == 1
+        assert len([r for r in results if r['action'] == 'uploaded']) == 2
+        assert len(fixture.state()['files']) == 2
+
+    def test_dry_run_writes_nothing(self):
+        fixture = FolderFixture(files=[
+            ('a.jpg', image_bytes(530, 1000), '2026-08-25T10:00:00Z', '2026-08-25T10:00:20Z'),
+        ])
+        results = fixture.run(dry_run=True)
+        assert [r['action'] for r in results if r['action'] == 'would-upload']
+        assert fixture.client.uploads == []
+
+
+class TestPartialFailures:
+    """Cases where an image could be uploaded twice, or lost entirely."""
+
+    def test_failed_metadata_put_does_not_re_upload_next_run(self):
+        session = Mock()
+        post_response = Mock(status_code=200, text='')
+        post_response.json.return_value = {'item_id': 'item-a', 'item_key': 'k'}
+        session.post.return_value = post_response
+        session.put.return_value = Mock(status_code=500, text='nope')
+
+        fixture = FolderFixture(files=[
+            ('a.jpg', image_bytes(530, 1000), '2026-08-25T10:00:00Z', '2026-08-25T10:00:20Z'),
+        ])
+        results = fixture.run(session=session)
+
+        uploaded = [r for r in results if r['action'] == 'uploaded']
+        assert len(uploaded) == 1 and 'metadata update returned 500' in uploaded[0]['metadata_error']
+        record = fixture.state()['files']['hash-a.jpg']
+        assert record['item_id'] == 'item-a'
+        assert 'metadata_error' in record, 'visible to a human, but never retried'
+
+        # Second run over the same folder: the item exists, so nothing is re-posted.
+        second = FolderFixture(
+            files=[('a.jpg', image_bytes(530, 1000), '2026-08-25T10:00:00Z', '2026-08-25T10:00:20Z')],
+            state=fixture.state())
+        session.post.reset_mock()
+        second.run(session=session)
+        assert session.post.call_count == 0
+
+    def test_duplicate_content_in_one_listing_uploads_once(self):
+        """Conflicted copies share a content hash — and the state file has one record per hash."""
+        data = image_bytes(530, 1000)
+        fixture = FolderFixture(files=[
+            ('a.jpg', data, '2026-08-25T10:00:00Z', '2026-08-25T10:00:20Z', 'same-hash'),
+            ('a (conflicted copy).jpg', data, '2026-08-25T10:00:05Z', '2026-08-25T10:00:25Z', 'same-hash'),
+        ])
+        session = upload_session()
+        results = fixture.run(session=session)
+
+        assert results[0]['duplicates'] == 1
+        assert len([r for r in results if r['action'] == 'uploaded']) == 1
+        assert session.post.call_count == 1
+        assert set(fixture.state()['files']) == {'same-hash'}
+
+    def test_short_download_is_retryable_not_a_permanent_skip(self):
+        fixture = FolderFixture(files=[
+            ('a.jpg', image_bytes(530, 1000), '2026-08-25T10:00:00Z', '2026-08-25T10:00:20Z'),
+        ])
+        fixture.client.files['/archive/ws/a.jpg'] = (b'truncated', 'rev-a.jpg')
+        results = fixture.run(session=upload_session())
+
+        assert [r for r in results if r['action'] == 'error']
+        state = fixture.state()
+        assert 'hash-a.jpg' in state['failed'] and 'hash-a.jpg' not in state['skipped']
+
+    def test_quarantined_files_are_reported_every_run(self):
+        state = dict(empty_state('ws-1'),
+                     failed={'hash-a.jpg': {'path': '/archive/ws/a.jpg', 'error': 'boom',
+                                            'attempts': MAX_FILE_ATTEMPTS}})
+        fixture = FolderFixture(
+            files=[('a.jpg', image_bytes(530, 1000), '2026-08-25T10:00:00Z', '2026-08-25T10:00:20Z')],
+            state=state)
+        results = fixture.run(session=upload_session())
+
+        quarantined = [r for r in results if r['action'] == 'quarantined']
+        assert len(quarantined) == 1 and quarantined[0]['attempts'] == MAX_FILE_ATTEMPTS
+        assert results[0]['quarantined'] == 1
+
+    def test_batch_history_is_persisted_per_chunk(self):
+        """After the first flush, history must describe what was processed, not the whole run."""
+        files = [(f'a{i}.jpg', image_bytes(530, 1000), f'2026-08-25T10:0{i}:00Z',
+                  f'2026-08-25T10:0{i}:20Z') for i in range(4)]
+        files += [('b0.jpg', image_bytes(530, 1000), '2026-08-25T11:00:00Z', '2026-08-25T11:00:20Z')]
+        fixture = FolderFixture(files=files)
+
+        calls = {'count': 0}
+        real_upload = fixture.client.upload
+
+        def upload(path, data, rev=None):
+            # Fail the second state flush, i.e. after chunk one has been uploaded.
+            if path.endswith('chronomaps.state.json'):
+                calls['count'] += 1
+                if calls['count'] > 1:
+                    raise RuntimeError('interrupted')
+            return real_upload(path, data, rev)
+
+        fixture.client.upload = upload
+        with pytest.raises(RuntimeError):
+            fixture.run(session=upload_session())
+
+        batches = fixture.state()['recent_batches']
+        assert len(batches) == 1, 'only the batch that was actually processed'
+        assert batches[0]['last_scanned_at'] == '2026-08-25T10:03:00Z'
+
+
+class TestRunIngest:
+    def test_bad_credentials_in_one_folder_do_not_stop_the_others(self):
+        broken, healthy = folder_entry('/archive/broken'), folder_entry('/archive/ok')
+        client = FakeDropbox({
+            '/archive': [broken, healthy],
+            '/archive/broken': [file_entry('/archive/broken/chronomaps.config')],
+            '/archive/ok': [file_entry('/archive/ok/chronomaps.config')],
+        }, {
+            '/archive/broken/chronomaps.config': (b'workspace: ws\napi_key: k\nratio: 0,53\n', 'r'),
+            '/archive/ok/chronomaps.config': (b'workspace: ws-ok\napi_key: k\n', 'r'),
+        })
+        results = list(run_ingest(settings=make_settings(), client=client, dry_run=True, now=NOW))
+        assert [r for r in results if r['action'] == 'skip-folder' and 'bad credentials' in r['reason']]
+        assert [r for r in results if r.get('workspace') == 'ws-ok']
+        assert results[-1]['action'] == 'done'
+
+    def test_run_stops_at_the_deadline(self):
+        folders = [folder_entry(f'/archive/ws{i}') for i in range(3)]
+        client = FakeDropbox({'/archive': folders}, {})
+        settings = make_settings(run_deadline_seconds=-1)
+        results = list(run_ingest(settings=settings, client=client, dry_run=True, now=NOW))
+        deadline = [r for r in results if r['action'] == 'deadline']
+        assert deadline and deadline[0]['deferred'] == 3
+
+    def test_only_folder_filters_by_name(self):
+        wanted, other = folder_entry('/archive/ws-a'), folder_entry('/archive/ws-b')
+        client = FakeDropbox({'/archive': [wanted, other], '/archive/ws-a': []}, {})
+        results = list(run_ingest(settings=make_settings(), client=client, dry_run=True,
+                                  only_folder='ws-a', now=NOW))
+        folders = {r.get('folder') for r in results if r.get('folder')}
+        assert folders == {'ws-a'}
+
+    def test_folder_error_does_not_stop_the_run(self):
+        broken, healthy = folder_entry('/archive/broken'), folder_entry('/archive/ok')
+        client = FakeDropbox({
+            '/archive': [broken, healthy],
+            '/archive/broken': [file_entry('/archive/broken/chronomaps.config')],
+            '/archive/ok': [],
+        }, {'/archive/broken/chronomaps.config': (b'workspace: ws\napi_key: k\n', 'r')})
+        client.files['/archive/broken/chronomaps.state.json'] = (b'{corrupt', 'r')
+        results = list(run_ingest(settings=make_settings(), client=client, now=NOW))
+        assert [r for r in results if r['action'] == 'error']
+        assert results[-1]['action'] == 'done'

--- a/scripts/dropbox_authorize.py
+++ b/scripts/dropbox_authorize.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""One-time setup: mint a Dropbox refresh token for the ingest function.
+
+Prerequisites — a scoped app at https://www.dropbox.com/developers/apps with
+Full Dropbox access, the four ingest permissions granted, and access tokens set
+to short-lived.
+
+Two steps, so the browser round-trip does not have to be interactive:
+
+  # 1. print the URL to approve
+  python scripts/dropbox_authorize.py --key-file ../dropbox-app-key.txt \\
+      --secret-file ../dropbox-app-secret.txt --url-only
+
+  # 2. exchange the code Dropbox shows you
+  python scripts/dropbox_authorize.py --key-file ../dropbox-app-key.txt \\
+      --secret-file ../dropbox-app-secret.txt --code <CODE> \\
+      --output ../dropbox-refresh-token.txt
+
+Prefer --key-file/--secret-file over --app-key/--app-secret: arguments are
+visible in the process list and in shell history. Likewise --output keeps the
+refresh token — a long-lived credential — out of your terminal scrollback.
+
+Store the result with:
+  firebase functions:secrets:set DROPBOX_REFRESH_TOKEN --project chronomaps3
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / 'functions'))
+
+from dropbox_ingest.dropbox_api import SCOPES, authorize_url, exchange_code  # noqa: E402
+
+
+def read_credential(value, path, label, parser):
+    if value:
+        return value.strip()
+    if path:
+        try:
+            return Path(path).read_text().strip()
+        except OSError as e:
+            parser.error(f'cannot read {label} from {path}: {e}')
+    parser.error(f'provide --{label} or --{label.replace("app-", "")}-file')
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Obtain a Dropbox refresh token')
+    parser.add_argument('--app-key')
+    parser.add_argument('--app-secret')
+    parser.add_argument('--key-file', help='File holding the app key')
+    parser.add_argument('--secret-file', help='File holding the app secret')
+    parser.add_argument('--code', help='Authorization code from the browser (skips the prompt)')
+    parser.add_argument('--url-only', action='store_true', help='Print the authorize URL and stop')
+    parser.add_argument('--output', help='Write the refresh token here instead of printing it')
+    args = parser.parse_args()
+
+    app_key = read_credential(args.app_key, args.key_file, 'app-key', parser)
+    app_secret = read_credential(args.app_secret, args.secret_file, 'app-secret', parser)
+
+    if args.url_only:
+        print(f'Requesting scopes: {SCOPES}\n')
+        print('Open this URL, approve, and copy the code Dropbox shows you:\n')
+        print('   ' + authorize_url(app_key))
+        return 0
+
+    code = args.code
+    if not code:
+        print(f'Requesting scopes: {SCOPES}\n')
+        print('1. Open this URL and approve access:\n')
+        print('   ' + authorize_url(app_key) + '\n')
+        code = input('2. Paste the authorization code here: ').strip()
+
+    tokens = exchange_code(app_key, app_secret, code.strip())
+    refresh_token = tokens.get('refresh_token')
+    if not refresh_token:
+        print('No refresh token returned — check that the app is a scoped app with short-lived '
+              'access tokens, then request a fresh code.')
+        print({k: v for k, v in tokens.items() if k != 'access_token'})
+        return 1
+
+    granted = tokens.get('scope', '')
+    missing = [scope for scope in SCOPES.split() if scope not in granted.split()]
+    if missing:
+        # A token minted before the Permissions tab was submitted silently lacks
+        # scopes, and the failure only shows up much later as a 401 mid-ingest.
+        print(f'Warning: the token is missing {", ".join(missing)} — grant them on the app\'s '
+              'Permissions tab, then re-run this to get a new code.')
+
+    if args.output:
+        path = Path(args.output)
+        path.write_text(refresh_token + '\n')
+        path.chmod(0o600)
+        print(f'Refresh token written to {path} (chmod 600)')
+    else:
+        print('\nRefresh token:\n')
+        print('   ' + refresh_token + '\n')
+
+    print('Account id:', tokens.get('account_id'))
+    print('Scopes:', granted or '(none reported)')
+    print('\nStore it with:  firebase functions:secrets:set DROPBOX_REFRESH_TOKEN --project chronomaps3')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/dropbox_check.py
+++ b/scripts/dropbox_check.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Verify the Dropbox setup before the ingest runs for real.
+
+Answers, in one command: do the credentials work, is a team namespace needed,
+does the root path exist, and which subfolders would be ingested (and why not).
+
+Usage:
+  python scripts/dropbox_check.py
+  python scripts/dropbox_check.py --env-file .env.dropbox
+
+Reads the same variables as the function: DROPBOX_APP_KEY, DROPBOX_APP_SECRET,
+DROPBOX_REFRESH_TOKEN, DROPBOX_ROOT_PATH, and optionally DROPBOX_NAMESPACE_ID,
+DROPBOX_FOLDER_CUTOFF.
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / 'functions'))
+
+from dropbox_ingest import (  # noqa: E402
+    ConfigurationError, find_config_entry, folder_created_at, is_image, make_client,
+    parse_credentials, DEFAULT_FOLDER_CUTOFF,
+)
+from dropbox_ingest.dropbox_api import (  # noqa: E402
+    DropboxClient, DropboxError, parse_timestamp, team_namespace_id,
+)
+
+OK, BAD, WARN = '✓', '✗', '!'
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Check the Dropbox ingest configuration')
+    parser.add_argument('--env-file', help='Read configuration from a KEY=VALUE file first')
+    args = parser.parse_args()
+
+    if args.env_file:
+        for line in Path(args.env_file).read_text().splitlines():
+            line = line.strip()
+            if line and not line.startswith('#') and '=' in line:
+                key, value = line.split('=', 1)
+                os.environ.setdefault(key.strip(), value.strip().strip('"\''))
+
+    missing = [name for name in ('DROPBOX_APP_KEY', 'DROPBOX_APP_SECRET', 'DROPBOX_REFRESH_TOKEN')
+               if not os.environ.get(name)]
+    if missing:
+        print(f'{BAD} Missing: {", ".join(missing)}')
+        return 1
+
+    # Secret values often arrive with a trailing newline (e.g. from a data file).
+    client = DropboxClient(os.environ['DROPBOX_APP_KEY'].strip(),
+                           os.environ['DROPBOX_APP_SECRET'].strip(),
+                           os.environ['DROPBOX_REFRESH_TOKEN'].strip(),
+                           namespace_id=(os.environ.get('DROPBOX_NAMESPACE_ID') or '').strip() or None)
+
+    try:
+        account = client.get_current_account()
+    except DropboxError as e:
+        print(f'{BAD} Could not authenticate: {e}')
+        return 1
+    name = (account.get('name') or {}).get('display_name', '?')
+    print(f'{OK} Authenticated as {name} <{account.get("email", "?")}>')
+
+    namespace = team_namespace_id(account)
+    configured = os.environ.get('DROPBOX_NAMESPACE_ID')
+    if namespace and not configured:
+        print(f'{WARN} This account has a team space. If the scan folder lives there, set:')
+        print(f'      DROPBOX_NAMESPACE_ID={namespace}')
+    elif configured:
+        print(f'{OK} Using namespace {configured}')
+
+    root = os.environ.get('DROPBOX_ROOT_PATH', '').strip()
+    if not root:
+        print(f'{WARN} DROPBOX_ROOT_PATH is not set — top-level folders in this account:')
+        return list_children(client, '', limit=40)
+
+    try:
+        folders = [e for e in client.list_folder(root) if e.get('.tag') == 'folder']
+    except DropboxError as e:
+        print(f'{BAD} Cannot list {root}: {e}')
+        print('      Check the path (it is case-insensitive but must start with /), and whether it '
+              'lives in the team space (see the namespace hint above).')
+        return 1
+
+    cutoff = parse_timestamp(os.environ.get('DROPBOX_FOLDER_CUTOFF') or DEFAULT_FOLDER_CUTOFF)
+    print(f'{OK} Root {root}: {len(folders)} subfolders, cutoff {cutoff.date()}\n')
+
+    eligible = 0
+    for folder in sorted(folders, key=lambda f: f.get('name', '')):
+        eligible += describe_folder(client, folder, cutoff)
+    print(f'\n{eligible} folder(s) would be ingested on the next run.')
+    return 0
+
+
+def describe_folder(client, folder, cutoff):
+    """Print one folder's verdict; return 1 if it would be ingested."""
+    path = folder.get('path_display')
+    name = folder.get('name')
+    try:
+        entries = list(client.list_folder(path, recursive=True))
+    except DropboxError as e:
+        print(f'{BAD} {name}: cannot list ({e})')
+        return 0
+
+    config_entry = find_config_entry(entries, folder.get('path_lower', path))
+    images = [e for e in entries if is_image(e)]
+    created = folder_created_at(entries)
+
+    if not config_entry:
+        print(f'   {name}: no credentials file ({len(images)} images) — skipped')
+        return 0
+
+    try:
+        config = parse_credentials(client.download(config_entry['path_display']).decode('utf-8', 'replace'))
+    except ConfigurationError as e:
+        print(f'{BAD} {name}: {config_entry["name"]} is invalid — {e}')
+        return 0
+
+    created_label = created.date() if created else 'unknown'
+    if not config.enabled:
+        print(f'   {name}: disabled in {config_entry["name"]} — skipped')
+        return 0
+    if created and created < cutoff and not config.ignore_cutoff:
+        print(f'   {name}: created {created_label}, before the cutoff — skipped '
+              f'(add `ignore_cutoff: true` to ingest it anyway)')
+        return 0
+
+    print(f'{OK} {name}: workspace {config.workspace}, created {created_label}, '
+          f'{len(images)} images would be considered')
+    return 1
+
+
+def list_children(client, path, limit):
+    for entry in list(client.list_folder(path))[:limit]:
+        if entry.get('.tag') == 'folder':
+            print('      ', entry.get('path_display'))
+    return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Scanned workshop pages land in a Dropbox folder — one subfolder per workspace — and until now had to be uploaded by hand. This adds a scheduled function that picks them up on its own.

## What it does

Every 5 minutes, `dropbox_ingest_scheduled` lists the subfolders of `DROPBOX_ROOT_PATH` and ingests the ones that hold a credentials file **and** were created after `DROPBOX_FOLDER_CUTOFF` (default 2026-08-20). New scans are centre-cropped to the 0.53:1 page ratio, or rejected when further than 10% off — the same tolerance the scanner UI enforces in `checkDimensions`. Uploads go through the path the app already uses in automatic mode:

```
POST {screenshot_handler}?workspace=…&api_key=…&automatic=true    → creates the item
PUT  {chronomaps_api}/<workspace>/<item_id>?item-key=…            → author_id + provenance
```

Bookkeeping metadata deliberately does **not** ride in the handler's `metadata` form field: that field is fed to the vision prompt as user-provided truth.

The collaborate key is sufficient for all three calls the ingest makes, so no admin credential needs to sit in a shared Dropbox folder.

## Batching → shared `author_id`

Scans are grouped by gap between **scan** times (`client_modified`), so Dropbox sync lag changes *when* an image is ingested but never *which* batch it lands in. The last 10 batches are remembered with their scan windows, so a page that syncs an hour late rejoins its own batch instead of whichever batch ran most recently.

## Not uploading anything twice

- Dedup is keyed on Dropbox's own `content_hash` — a moved or duplicated copy is recognised without downloading it, and duplicates within one listing collapse to a single upload.
- State is a `chronomaps.state.json` written back into each Dropbox folder, using add/update revision modes so a concurrent writer merges rather than clobbers. A Firestore lease stops two scheduled runs overlapping.
- A failed metadata `PUT` still records the item: it already exists, so retrying would duplicate it. The error is stored as `metadata_error` for a human to repair.
- Transient trouble (short download, OOM) is a retryable failure, not a permanent skip. Three failures quarantine a file — and quarantined files are reported on every later run, so nothing disappears silently.

## Configuration

Only real credentials go in Secret Manager (`DROPBOX_APP_KEY`, `DROPBOX_APP_SECRET`, `DROPBOX_REFRESH_TOKEN`, already created). Root path and cutoff ship in `functions/.env.chronomaps3`, so a deploy from CI needs no hand-created secrets — every name in a function's `secrets=[…]` must exist or the deploy fails, and Secret Manager rejects empty values.

## Also included

- `scripts/dropbox_authorize.py` — mint a refresh token (file-based in/out, so credentials stay out of shell history and scrollback)
- `scripts/dropbox_check.py` — verify the connection, detect a team-space namespace, list which folders would be ingested and why the others would not
- `dropbox_ingest_cli.py` — dry runs and manual runs, same code path as the function
- `docs/DROPBOX_SETUP.md` — repeatable setup manual, plus a "Dropbox Auto-Ingest" section in `docs/API.md`

## Testing

74 new unit tests against a fake Dropbox, covering credential parsing, cutoff eligibility, content-hash dedup, state-file conflict merges, batch assignment across run boundaries, crop maths and tolerance boundaries, partial-failure recording, quarantine, transport retries and the token-refresh lock. Full suite: 261 passed, 2 failed — both in `test_taxonomy.py::TestUseItem`, and both reproduce on `main` untouched by this branch.

Verified end to end against live Dropbox and the deployed API: two pages ingested with a shared `author_id`, an off-ratio image skipped with its reason recorded, and a second run uploading nothing.

## Notes for the reviewer

- The metadata `PUT` mirrors `screenshot_handler.update_item` rather than importing it — that module pulls in `firebase_admin.storage` and the OpenAI secret at import time, which would break the CLI and the tests.
- Residual risk, by design: if the container is killed mid-chunk, up to 4 images can be uploaded-but-unrecorded and re-uploaded next run. Bounding that further would need a pre-commit journal.
- `docs/API.md` documents the API URL as `…cloudfunctions.net/chronomaps_api` while the deployed URL is the Cloud Run form; `derive_handler_url` handles both and raises on anything else rather than silently POSTing to the wrong endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hdp8CFMcmfFTeQnmK15Aup
