### PR TITLE
Deploy the Dropbox ingest functions

### DIFF
--- a/functions/functions.yaml
+++ b/functions/functions.yaml
@@ -1,3 +1,14 @@
+# Firebase deployment manifest.
+#
+# firebase-tools reads this file INSTEAD of discovering the decorators in
+# main.py, so:
+#   * a new @https_fn / @scheduler_fn function is NOT deployed until it is
+#     listed here - the deploy succeeds and simply omits it, silently;
+#   * the values here win over the decorator, including `schedule` (note that
+#     enhance_all_daily and cluster_its_time run far less often here than
+#     main.py suggests).
+# Keep an entry in sync with its decorator, or delete this file to go back to
+# discovery - but check the schedules before you do.
 endpoints:
   chronomaps_api:
     availableMemoryMb: 1024
@@ -220,6 +231,48 @@ endpoints:
     - key: SERVICE_ACCOUNT_JSON
     serviceAccountEmail: null
     timeoutSeconds: 540
+  dropbox_ingest:
+    availableMemoryMb: 2048
+    concurrency: null
+    entryPoint: dropbox_ingest
+    httpsTrigger: {}
+    ingressSettings: null
+    labels: {}
+    maxInstances: null
+    minInstances: null
+    platform: gcfv2
+    region:
+    - europe-west4
+    secretEnvironmentVariables:
+    - key: SERVICE_ACCOUNT_JSON
+    - key: CHRONOMAPS_API_URL
+    - key: DROPBOX_APP_KEY
+    - key: DROPBOX_APP_SECRET
+    - key: DROPBOX_REFRESH_TOKEN
+    serviceAccountEmail: null
+    timeoutSeconds: 1800
+  dropbox_ingest_scheduled:
+    availableMemoryMb: 2048
+    concurrency: null
+    entryPoint: dropbox_ingest_scheduled
+    ingressSettings: null
+    labels: {}
+    maxInstances: 1
+    minInstances: null
+    platform: gcfv2
+    region:
+    - europe-west1
+    scheduleTrigger:
+      retryConfig: {}
+      schedule: every 5 minutes
+    secretEnvironmentVariables:
+    - key: SERVICE_ACCOUNT_JSON
+    - key: CHRONOMAPS_API_URL
+    - key: DROPBOX_APP_KEY
+    - key: DROPBOX_APP_SECRET
+    - key: DROPBOX_REFRESH_TOKEN
+    serviceAccountEmail: null
+    timeoutSeconds: 1800
 params:
 - name: OPENAI_API_KEY
   type: secret
@@ -228,6 +281,12 @@ params:
 - name: SERVICE_ACCOUNT_JSON
   type: secret
 - name: CONFIG__ITS_TIME
+  type: secret
+- name: DROPBOX_APP_KEY
+  type: secret
+- name: DROPBOX_APP_SECRET
+  type: secret
+- name: DROPBOX_REFRESH_TOKEN
   type: secret
 requiredAPIs:
 - api: cloudscheduler.googleapis.com


### PR DESCRIPTION
#26 deployed green, but neither `dropbox_ingest` nor `dropbox_ingest_scheduled` exists in the project. `firebase functions:list` shows the same 13 functions as before.

## Why

`functions/functions.yaml` is a static deployment manifest, and firebase-tools reads it **instead of** discovering the decorators in `main.py`. The deploy log bears this out — every one of the 13 endpoints listed in that file was updated, and the two new ones are never mentioned at all:

```
i  functions: Loading and analyzing source code for codebase default to determine what to deploy
i  functions: Loaded environment variables from .env.chronomaps3.
✔  functions[chronomaps_api(europe-west4)] Successful update operation.
… 13 of these, none for dropbox_ingest*
```

No warning, no error, exit code 0. A function that isn't in the manifest simply doesn't deploy.

The same mechanism explains something else worth knowing: the schedules in the manifest override the decorators. `enhance_all_daily` says `every day 03:00` in `main.py` but `every saturday 03:00` here (commit "Less frequent"), and `cluster_its_time` says `every 15 minutes` in code but `every friday 03:00` here. **The manifest is the real config**, so I did not touch those.

## What this does

- Adds `dropbox_ingest` (https, europe-west4) and `dropbox_ingest_scheduled` (`every 5 minutes`, europe-west1) with their five secrets, matching the decorators in `main.py`.
- Adds the three `DROPBOX_*` secrets to the `params` block, alongside the existing ones.
- `maxInstances: 1` on the scheduled endpoint — a second line of defence beside the Firestore lease, so two runs can never ingest the same folder at once.
- A header comment on the file, so the next person adding a function doesn't lose an hour to a silently-successful deploy.

## After merge

The scheduler starts every 5 minutes. Two staged test scans are already waiting in `99-99-99-upload-tester`; if the ingest works, they appear in that workspace with a shared `author_id` within about five minutes of the deploy, with no CLI involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hdp8CFMcmfFTeQnmK15Aup
