### PR TITLE
Ingest: list the Dropbox root once instead of per folder

### DIFF
--- a/functions/dropbox_ingest/__init__.py
+++ b/functions/dropbox_ingest/__init__.py
@@ -228,10 +228,24 @@ def empty_state(workspace):
     }
 
 
-def read_state(client, folder_path, workspace):
-    """Return `(state, rev)`; rev is None when there is no state file yet."""
+def read_state(client, folder_path, workspace, entries=None):
+    """Return `(state, rev)`; rev is None when there is no state file yet.
+
+    `entries` is the folder's listing when the caller already has it — the state
+    file's metadata is in there, so looking it up again would be a wasted call.
+    """
     path = f'{folder_path}/{STATE_FILENAME}'
-    metadata = client.get_metadata(path)
+    if entries is None:
+        metadata = client.get_metadata(path)
+    else:
+        metadata = next((e for e in entries if e.get('.tag') == 'file'
+                         and e.get('path_lower') == path.lower()), None)
+        if metadata is None:
+            # The listing says there is no state file. Confirm it directly
+            # before treating the folder as never-ingested: acting on a stale
+            # listing would re-upload every image in it. Costs one call, and
+            # only for a folder that has not been ingested yet.
+            metadata = client.get_metadata(path)
     if not metadata:
         return empty_state(workspace), None
     try:
@@ -316,6 +330,34 @@ def write_state(client, folder_path, state, rev, attempts=3):
 
 
 # -- listing / eligibility --------------------------------------------------
+
+def group_entries(entries, root_path):
+    """Split one recursive listing of the root into per-folder buckets.
+
+    Asking Dropbox about each workspace folder separately costs one round trip
+    per folder — 36 of them, and about 45 seconds, to learn that nothing has
+    changed. One recursive listing answers the same question in a handful of
+    paged calls.
+
+    Returns `(folders, buckets)`: the top-level folder entries by name, and
+    each one's entries (at any depth below it).
+    """
+    prefix = root_path.lower().rstrip('/') + '/'
+    folders, buckets = {}, {}
+    for entry in entries:
+        path = entry.get('path_lower') or ''
+        if not path.startswith(prefix):
+            continue
+        relative = path[len(prefix):]
+        if not relative:
+            continue
+        top = relative.split('/', 1)[0]
+        if entry.get('.tag') == 'folder' and relative == top:
+            folders[top] = entry
+        else:
+            buckets.setdefault(top, []).append(entry)
+    return folders, buckets
+
 
 def is_image(entry):
     return (entry.get('.tag') == 'file'
@@ -473,13 +515,19 @@ def upload_scan(settings, config, image_bytes, filename, author_id, metadata, se
 
 # -- per-folder flow --------------------------------------------------------
 
-def process_folder(client, folder, settings, dry_run=False, now=None, session=None, deadline=None):
-    """Ingest one workspace folder, yielding status dicts as it goes."""
+def process_folder(client, folder, settings, dry_run=False, now=None, session=None,
+                   deadline=None, entries=None):
+    """Ingest one workspace folder, yielding status dicts as it goes.
+
+    `entries` is this folder's listing when the caller already has it (see
+    `group_entries`); without it the folder is listed here.
+    """
     now = now or _now()
     folder_path = folder.get('path_display') or folder.get('path_lower')
     name = folder.get('name', folder_path)
 
-    entries = list(client.list_folder(folder_path, recursive=True))
+    if entries is None:
+        entries = list(client.list_folder(folder_path, recursive=True))
     config_entry = find_config_entry(entries, folder.get('path_lower', folder_path))
     if not config_entry:
         yield dict(folder=name, action='skip-folder', reason='no credentials file')
@@ -502,7 +550,7 @@ def process_folder(client, folder, settings, dry_run=False, now=None, session=No
                    reason=f'created {_iso(created_at)}, before cutoff {_iso(settings.folder_cutoff)}')
         return
 
-    state, rev = read_state(client, folder_path, config.workspace)
+    state, rev = read_state(client, folder_path, config.workspace, entries)
 
     images = [e for e in entries if is_image(e)]
 
@@ -657,11 +705,15 @@ def run_ingest(settings=None, client=None, dry_run=False, only_folder=None, now=
     yield dict(action='start', root=settings.root_path, dry_run=dry_run,
                cutoff=_iso(settings.folder_cutoff))
 
-    folders = [e for e in client.list_folder(settings.root_path) if e.get('.tag') == 'folder']
+    listing = list(client.list_folder(settings.root_path, recursive=True))
+    folders_by_name, buckets = group_entries(listing, settings.root_path)
+
     if only_folder:
         wanted = only_folder.strip('/').lower()
-        folders = [f for f in folders if f.get('name', '').lower() == wanted
-                   or (f.get('path_lower') or '').strip('/') == wanted]
+        folders_by_name = {name: entry for name, entry in folders_by_name.items()
+                           if name == wanted or (entry.get('path_lower') or '').strip('/') == wanted}
+
+    folders = [folders_by_name[name] for name in sorted(folders_by_name)]
 
     processed = 0
     for folder in folders:
@@ -671,7 +723,8 @@ def run_ingest(settings=None, client=None, dry_run=False, only_folder=None, now=
         processed += 1
         try:
             yield from process_folder(client, folder, settings, dry_run=dry_run, now=now,
-                                      session=session, deadline=deadline)
+                                      session=session, deadline=deadline,
+                                      entries=buckets.get(folder.get('name', '').lower(), []))
         except Exception as e:                                  # noqa: BLE001
             # One folder's problem (a corrupt state file, a Dropbox hiccup)
             # must never stop the other workspaces from being ingested.

--- a/functions/tests/test_dropbox_ingest.py
+++ b/functions/tests/test_dropbox_ingest.py
@@ -15,7 +15,7 @@ import pytest
 from PIL import Image
 
 from dropbox_ingest import (
-    ConfigurationError, FolderConfig, Settings, assign_batches, batches_from,
+    ConfigurationError, FolderConfig, Settings, assign_batches, batches_from, group_entries,
     derive_handler_url, empty_state, entry_key, find_config_entry, folder_created_at,
     is_known, merge_batches, merge_states, parse_credentials, process_folder, read_state,
     run_ingest, scan_time, upload_scan, write_state, MAX_FILE_ATTEMPTS,
@@ -75,16 +75,27 @@ class FakeDropbox:
         self.files = files or {}
         self.uploads = []
         self.rev_counter = 0
+        self.calls = {'list_folder': 0, 'get_metadata': 0, 'download': 0, 'upload': 0}
 
     def list_folder(self, path, recursive=False):
-        return iter(self.entries_by_folder.get(path, []))
+        self.calls['list_folder'] += 1
+        entries = list(self.entries_by_folder.get(path, []))
+        if recursive:
+            # Real Dropbox returns everything below `path`, at any depth.
+            prefix = path.rstrip('/') + '/'
+            for other, extra in self.entries_by_folder.items():
+                if other != path and other.startswith(prefix):
+                    entries.extend(extra)
+        return iter(entries)
 
     def get_metadata(self, path):
+        self.calls['get_metadata'] += 1
         if path in self.files:
             return {'.tag': 'file', 'path_display': path, 'rev': self.files[path][1]}
         return None
 
     def download(self, path):
+        self.calls['download'] += 1
         if path not in self.files:
             raise AssertionError(f'unexpected download of {path}')
         return self.files[path][0]
@@ -781,6 +792,67 @@ class TestPartialFailures:
         batches = fixture.state()['recent_batches']
         assert len(batches) == 1, 'only the batch that was actually processed'
         assert batches[0]['last_scanned_at'] == '2026-08-25T10:03:00Z'
+
+
+class TestGroupEntries:
+    def test_splits_a_recursive_listing_by_top_level_folder(self):
+        listing = [
+            folder_entry('/archive/ws-a'),
+            folder_entry('/archive/ws-b'),
+            file_entry('/archive/ws-a/chronomaps.config'),
+            file_entry('/archive/ws-a/sub/deep.jpg'),
+            file_entry('/archive/ws-b/page.jpg'),
+        ]
+        folders, buckets = group_entries(listing, '/archive')
+        assert set(folders) == {'ws-a', 'ws-b'}
+        assert {e['name'] for e in buckets['ws-a']} == {'chronomaps.config', 'deep.jpg'}
+        assert {e['name'] for e in buckets['ws-b']} == {'page.jpg'}
+
+    def test_ignores_entries_outside_the_root(self):
+        listing = [folder_entry('/elsewhere/ws'), file_entry('/elsewhere/ws/a.jpg')]
+        folders, buckets = group_entries(listing, '/archive')
+        assert folders == {} and buckets == {}
+
+    def test_nested_folders_are_not_treated_as_workspaces(self):
+        listing = [folder_entry('/archive/ws'), folder_entry('/archive/ws/round-2')]
+        folders, _buckets = group_entries(listing, '/archive')
+        assert set(folders) == {'ws'}
+
+
+class TestListingCost:
+    """The point of the single listing: an idle sweep must not scale with folders."""
+
+    def _idle_client(self, folder_count):
+        folders = [folder_entry(f'/archive/ws-{i}') for i in range(folder_count)]
+        entries = {'/archive': folders}
+        for folder in folders:
+            entries[folder['path_display']] = [file_entry(f"{folder['path_display']}/notes.txt")]
+        return FakeDropbox(entries, {})
+
+    def test_idle_sweep_lists_once_regardless_of_folder_count(self):
+        for folder_count in (5, 40):
+            client = self._idle_client(folder_count)
+            list(run_ingest(settings=make_settings(), client=client, now=NOW))
+            assert client.calls['list_folder'] == 1, f'{folder_count} folders should still be one listing'
+            assert client.calls['get_metadata'] == 0
+            assert client.calls['download'] == 0
+
+    def test_active_folder_does_not_re_look_up_its_state_file(self):
+        state = dict(empty_state('ws-1'), files={'hash-a.jpg': {'item_id': 'x'}})
+        fixture = FolderFixture(
+            files=[('a.jpg', image_bytes(530, 1000), '2026-08-25T10:00:00Z', '2026-08-25T10:00:20Z')],
+            state=state)
+        list(run_ingest(settings=make_settings(), client=fixture.client, now=NOW))
+        # config + state downloads, and no separate metadata lookup for the state file
+        assert fixture.client.calls['get_metadata'] == 0
+        assert fixture.client.calls['download'] == 2
+
+    def test_missing_state_file_is_confirmed_before_re_ingesting(self):
+        """A stale listing must not be trusted into re-uploading everything."""
+        fixture = FolderFixture(
+            files=[('a.jpg', image_bytes(530, 1000), '2026-08-25T10:00:00Z', '2026-08-25T10:00:20Z')])
+        list(run_ingest(settings=make_settings(), client=fixture.client, dry_run=True, now=NOW))
+        assert fixture.client.calls['get_metadata'] == 1
 
 
 class TestRunIngest:


### PR DESCRIPTION
First of two PRs on ingest cost. An idle sweep — the normal state, where nothing has been scanned — took **~50 seconds and ~43 API calls**, essentially all of it one round trip per workspace folder to ask "anything new?" about folders that never change.

## Change

One recursive listing of the root, split into per-folder buckets by `group_entries`. `process_folder` and `read_state` take the slice the caller already has instead of fetching it again.

Measured against the live archive (36 folders, ~4000 files):

| | before | after |
|---|---|---|
| idle sweep | ~50s | **8.8s** |
| Dropbox API calls | ~43 | **8** (4 of them the paged root listing) |

## One deliberate call kept

`read_state` uses the listing to find the state file, but when the listing shows *no* state file it still does a `get_metadata` to confirm. A stale or incomplete listing that omitted the state file would otherwise read as "never ingested" and re-upload every image in the folder. That call only happens for a folder that has not been ingested yet, so it costs nothing in steady state — and `test_missing_state_file_is_confirmed_before_re_ingesting` pins it.

## Tests

80 pass (6 new). `TestListingCost` guards the actual property: an idle sweep issues exactly one listing whether there are 5 folders or 40, no metadata lookups and no downloads. `TestGroupEntries` covers nested folders, entries outside the root, and deep files.

## What is left for the follow-up

The remaining 8.8s is dominated by paging ~4000 entries every 5 minutes to discover that nothing changed. The next PR replaces that with Dropbox's `list_folder/continue` cursor, which returns only what changed — one call, ~1s idle. That one needs care: a file deferred by the settle window is reported by the cursor only once, so the deferred set has to be persisted or those scans would never be ingested. Hence the split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hdp8CFMcmfFTeQnmK15Aup
