### PR TITLE
Ingest only the folders Dropbox says have changed

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1130,6 +1130,27 @@ the array of per-step status objects.
 starting new work after `DROPBOX_RUN_DEADLINE_SECONDS` (default 1500) so an interrupted chunk cannot
 be re-uploaded by the next run.
 
+### Which folders a run visits
+
+Listing every folder to discover that nothing changed cost ~50s per run. Instead, Dropbox's
+`list_folder/continue` cursor reports what changed since the previous run, and each changed folder is
+marked **dirty** in `chronomaps_global/dropbox_ingest_tracker` (`{root, cursor, dirty, full_sweep_at}`).
+Only dirty folders are visited, and the listing always comes fresh from the folder.
+
+A folder stays dirty until a pass leaves nothing behind — nothing deferred by the settle window, no
+`capped` remainder, no per-file errors, no deadline cut-off. That is what makes the scheme safe: the
+cursor reports each change exactly once, so a scan skipped for being too fresh would otherwise never
+be mentioned again; the flag is what brings the run back to it.
+
+The cursor and the dirty set are written together, before any uploading. Every
+`DROPBOX_FULL_SWEEP_HOURS` (default 6) — and on a first run, a changed root or a cursor Dropbox has
+retired — every folder is re-marked, so a missed change heals on its own rather than staying
+invisible. `POST /dropbox_ingest?full=true` forces that immediately.
+
+Measured on an archive of 36 folders / ~4000 files: an idle run is **1 API call, ~1.4s** (was ~43
+calls, ~50s); a full sweep is ~11 calls, ~10s. The CLI always uses its own in-memory tracker, so a
+manual run visits every folder and never disturbs the deployed function's cursor.
+
 Locally, the same code path runs via `python dropbox_ingest_cli.py --dry-run [--folder NAME]`.
 
 ---
@@ -1412,6 +1433,8 @@ manual setup:
   prints the value when it is needed)
 - `DROPBOX_SETTLE_SECONDS` - Optional; how long a file must be settled before ingest (default 180)
 - `DROPBOX_RUN_DEADLINE_SECONDS` - Optional; stop starting work after this long (default 1500)
+- `DROPBOX_FULL_SWEEP_HOURS` - Optional; how often every folder is re-marked regardless of the
+  cursor (default 6)
 - `SCREENSHOT_HANDLER_URL` - Optional; derived from `CHRONOMAPS_API_URL` when both follow the
   standard naming, required otherwise
 

--- a/dropbox_ingest_cli.py
+++ b/dropbox_ingest_cli.py
@@ -25,6 +25,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent / 'functions'))
 
 from dropbox_ingest import ConfigurationError, load_settings, run_ingest  # noqa: E402
+from dropbox_ingest import delta  # noqa: E402
 from dropbox_ingest.dropbox_api import DropboxError  # noqa: E402
 
 
@@ -57,7 +58,12 @@ def main():
 
     counts = {}
     try:
-        for bit in run_ingest(settings=settings, dry_run=args.dry_run, only_folder=args.folder):
+        # A local run keeps its own tracker: sharing the deployed function's
+        # cursor would make the scheduler skip changes this run consumed, and
+        # would need Firebase credentials here. Every CLI run therefore visits
+        # every folder, which is what you want from a manual run anyway.
+        for bit in run_ingest(settings=settings, dry_run=args.dry_run, only_folder=args.folder,
+                              tracker=delta.MemoryTracker()):
             counts[bit.get('action')] = counts.get(bit.get('action'), 0) + 1
             print(json.dumps(bit, ensure_ascii=False) if args.json else format_line(bit))
     except (DropboxError, ConfigurationError) as e:
@@ -73,6 +79,12 @@ def format_line(bit):
     folder = bit.get('folder', '')
     if action == 'start':
         return f"→ root {bit['root']}, cutoff {bit['cutoff']}{' (DRY RUN)' if bit['dry_run'] else ''}"
+    if action == 'delta':
+        return f"→ {bit['changed_entries']} changed entries, {bit['dirty']} folder(s) to visit"
+    if action == 'full-sweep':
+        return f"→ full sweep ({bit['reason']}): {bit['folders']} folders"
+    if action == 'forgotten':
+        return f"   gone  {folder}: {bit['reason']}"
     if action == 'skip-folder':
         return f"   skip  {folder}: {bit['reason']}"
     if action == 'folder':
@@ -105,7 +117,10 @@ def format_line(bit):
     if action == 'folder-done':
         return f"   done  {folder}: {bit['uploaded']} processed"
     if action == 'done':
-        return f"→ finished, {bit['folders']} folders considered"
+        line = f"→ finished, {bit['folders']} folders considered"
+        if bit.get('still_dirty'):
+            line += f", {bit['still_dirty']} still pending for the next run"
+        return line
     return json.dumps(bit, ensure_ascii=False)
 
 

--- a/functions/dropbox_ingest/__init__.py
+++ b/functions/dropbox_ingest/__init__.py
@@ -29,7 +29,10 @@ from io import BytesIO
 
 import requests
 
-from .dropbox_api import DropboxClient, DropboxConflict, DropboxError, parse_timestamp
+from . import delta
+from .dropbox_api import (
+    DropboxClient, DropboxConflict, DropboxCursorReset, DropboxError, parse_timestamp,
+)
 from .images import ImageRejected, RATIO_TOLERANCE, TARGET_RATIO, prepare_image
 
 CONFIG_FILENAMES = ('chronomaps.config', '.chronomaps.config', 'chronomaps.txt')
@@ -694,8 +697,15 @@ def _chunks(items, size):
 
 # -- entry point ------------------------------------------------------------
 
-def run_ingest(settings=None, client=None, dry_run=False, only_folder=None, now=None, session=None):
-    """Ingest every eligible workspace folder under the Dropbox root."""
+def run_ingest(settings=None, client=None, dry_run=False, only_folder=None, now=None,
+               session=None, tracker=None, full_sweep=False):
+    """Ingest the workspace folders that have changed since the last run.
+
+    Folders are visited only when Dropbox reports a change in them, and stay on
+    the list until a pass leaves nothing behind (see `delta`). `full_sweep`
+    forces every folder to be visited; `only_folder` is an explicit manual run
+    and leaves the stored cursor alone.
+    """
     settings = settings or load_settings()
     client = client or make_client(settings)
     now = now or _now()
@@ -705,29 +715,103 @@ def run_ingest(settings=None, client=None, dry_run=False, only_folder=None, now=
     yield dict(action='start', root=settings.root_path, dry_run=dry_run,
                cutoff=_iso(settings.folder_cutoff))
 
-    listing = list(client.list_folder(settings.root_path, recursive=True))
-    folders_by_name, buckets = group_entries(listing, settings.root_path)
+    if only_folder:
+        store, stored = delta.MemoryTracker(), delta.empty_tracker()
+    else:
+        store = tracker if tracker is not None else delta.FirestoreTracker()
+        stored = store.load()
+
+    dirty = set(stored.get('dirty') or [])
+    sweep_all = full_sweep or bool(only_folder)
+    reason = None
+
+    if not sweep_all:
+        if stored.get('root') != settings.root_path or not stored.get('cursor'):
+            reason = 'first run for this root'
+        elif delta.full_sweep_due(stored, now):
+            reason = 'periodic full sweep'
+        else:
+            try:
+                changes, cursor = client.list_folder_changes(stored['cursor'])
+                dirty |= delta.dirty_folders(changes, settings.root_path)
+                stored['cursor'] = cursor
+                yield dict(action='delta', changed_entries=len(changes), dirty=len(dirty))
+            except DropboxCursorReset:
+                reason = 'cursor reset by Dropbox'
+
+    # Resolving folder entries costs a listing, so only do it when there is
+    # something to resolve: an idle run should touch nothing at all.
+    by_name, buckets = None, {}
+    if reason or sweep_all:
+        # A sweep visits every folder, so one recursive listing of the root is
+        # far cheaper than a listing per folder.
+        listing = list(client.list_folder(settings.root_path, recursive=True))
+        by_name, buckets = group_entries(listing, settings.root_path)
+        dirty |= set(by_name)
+        stored['full_sweep_at'] = _iso(now)
+        if not only_folder:
+            stored['cursor'] = client.list_folder_cursor(settings.root_path, recursive=True)
+        if reason:
+            yield dict(action='full-sweep', reason=reason, folders=len(dirty))
 
     if only_folder:
         wanted = only_folder.strip('/').lower()
-        folders_by_name = {name: entry for name, entry in folders_by_name.items()
-                           if name == wanted or (entry.get('path_lower') or '').strip('/') == wanted}
+        dirty = {name for name in dirty if name == wanted}
 
-    folders = [folders_by_name[name] for name in sorted(folders_by_name)]
+    if dirty and by_name is None:
+        by_name = _folders_by_name(client, settings.root_path)
+    by_name = by_name or {}
+
+    # Folders that have since been deleted cannot be processed; drop them.
+    missing = dirty - set(by_name)
+    dirty -= missing
+    for name in sorted(missing):
+        yield dict(folder=name, action='forgotten', reason='folder no longer exists')
+
+    stored['root'] = settings.root_path
+    stored['dirty'] = sorted(dirty)
+    # Persisted before any work: if the cursor advanced but the dirty set did
+    # not, those changes would never be reported again.
+    if not dry_run:
+        store.save(stored)
 
     processed = 0
-    for folder in folders:
+    for name in sorted(dirty):
         if time.monotonic() > deadline:
-            yield dict(action='deadline', deferred=len(folders) - processed)
+            yield dict(action='deadline', deferred=len(dirty) - processed)
             break
         processed += 1
         try:
-            yield from process_folder(client, folder, settings, dry_run=dry_run, now=now,
+            leftovers = False
+            for bit in process_folder(client, by_name[name], settings, dry_run=dry_run, now=now,
                                       session=session, deadline=deadline,
-                                      entries=buckets.get(folder.get('name', '').lower(), []))
+                                      entries=buckets.get(name)):
+                leftovers = leftovers or _leaves_work_behind(bit)
+                yield bit
         except Exception as e:                                  # noqa: BLE001
             # One folder's problem (a corrupt state file, a Dropbox hiccup)
             # must never stop the other workspaces from being ingested.
-            yield dict(folder=folder.get('name'), action='error', error=f'{type(e).__name__}: {e}')
+            yield dict(folder=name, action='error', error=f'{type(e).__name__}: {e}')
+            continue
+        if not leftovers and not dry_run:
+            stored['dirty'] = sorted(set(stored['dirty']) - {name})
+            store.save(stored)
 
-    yield dict(action='done', folders=len(folders))
+    yield dict(action='done', folders=len(dirty), still_dirty=len(stored['dirty']))
+
+
+def _folders_by_name(client, root_path):
+    """Top-level folders of the root, keyed by lowercased name."""
+    return {(e.get('name') or '').lower(): e
+            for e in client.list_folder(root_path) if e.get('.tag') == 'folder'}
+
+
+def _leaves_work_behind(bit):
+    """Does this status mean the folder still has something to come back for?"""
+    action = bit.get('action')
+    if action in ('error', 'capped', 'deadline'):
+        return True
+    if action == 'folder':
+        # Scans still syncing are deliberately deferred to a later run.
+        return bool(bit.get('syncing'))
+    return False

--- a/functions/dropbox_ingest/delta.py
+++ b/functions/dropbox_ingest/delta.py
@@ -1,0 +1,97 @@
+"""Which folders are worth looking at this run.
+
+Listing every workspace folder to discover that nothing changed is the whole
+cost of an idle sweep. Dropbox will instead hand us only what changed since a
+cursor, so a run can go straight to the folders that need work.
+
+The cursor reports each change exactly once, which is a trap: a scan still
+inside the settle window would be seen once, skipped, and never mentioned
+again. So the cursor is used only to mark folders **dirty**, and a folder stays
+dirty until a pass over it completes with nothing left over — deferred,
+capped, failed or cut short by the deadline. The listing itself always comes
+from the folder, never from remembered per-file state.
+"""
+
+import datetime
+import os
+
+TRACKER_COLLECTION = 'chronomaps_global'
+TRACKER_DOCUMENT = 'dropbox_ingest_tracker'
+
+# How often to re-mark every folder, so a change we somehow missed still gets
+# picked up. The failure mode of a delta scheme is silence, not an error.
+FULL_SWEEP_INTERVAL_HOURS = int(os.environ.get('DROPBOX_FULL_SWEEP_HOURS', '') or 6)
+
+
+def empty_tracker():
+    return {'root': None, 'cursor': None, 'dirty': [], 'full_sweep_at': None}
+
+
+class FirestoreTracker:
+    """Cursor and dirty set, stored beside the ingest lock."""
+
+    def __init__(self, db=None):
+        self._db = db
+
+    @property
+    def db(self):
+        if self._db is None:
+            from firebase_admin import firestore
+            self._db = firestore.client()
+        return self._db
+
+    def load(self):
+        snapshot = self.db.collection(TRACKER_COLLECTION).document(TRACKER_DOCUMENT).get()
+        stored = snapshot.to_dict() if snapshot else None
+        if not stored:
+            return empty_tracker()
+        tracker = empty_tracker()
+        tracker.update({k: v for k, v in stored.items() if k in tracker})
+        return tracker
+
+    def save(self, tracker):
+        self.db.collection(TRACKER_COLLECTION).document(TRACKER_DOCUMENT).set(tracker)
+
+
+class MemoryTracker:
+    """Non-persistent tracker: manual runs, dry runs and tests."""
+
+    def __init__(self, tracker=None):
+        self.tracker = tracker or empty_tracker()
+
+    def load(self):
+        return dict(self.tracker)
+
+    def save(self, tracker):
+        self.tracker = dict(tracker)
+
+
+def dirty_folders(entries, root_path):
+    """Top-level folder names touched by a set of changed entries.
+
+    Any change counts — a new scan, a credentials file appearing, a state file
+    being deleted to force a re-upload. Classifying them here would only add a
+    way to miss one.
+    """
+    prefix = root_path.lower().rstrip('/') + '/'
+    names = set()
+    for entry in entries:
+        path = entry.get('path_lower') or ''
+        if not path.startswith(prefix):
+            continue
+        relative = path[len(prefix):]
+        if not relative:
+            continue
+        names.add(relative.split('/', 1)[0])
+    return names
+
+
+def full_sweep_due(tracker, now, interval_hours=FULL_SWEEP_INTERVAL_HOURS):
+    stamp = tracker.get('full_sweep_at')
+    if not stamp:
+        return True
+    try:
+        last = datetime.datetime.fromisoformat(stamp.replace('Z', '+00:00'))
+    except (AttributeError, ValueError):
+        return True
+    return now - last >= datetime.timedelta(hours=interval_hours)

--- a/functions/dropbox_ingest/dropbox_api.py
+++ b/functions/dropbox_ingest/dropbox_api.py
@@ -49,6 +49,10 @@ class DropboxConflict(DropboxError):
     """A write lost a race (rev mismatch) and must be retried."""
 
 
+class DropboxCursorReset(DropboxError):
+    """Dropbox invalidated the listing cursor; the caller must start over."""
+
+
 def parse_timestamp(value):
     """Parse a Dropbox ISO-8601 timestamp (always UTC, 'Z' suffixed)."""
     if not value:
@@ -186,6 +190,42 @@ class DropboxClient:
     def get_current_account(self):
         """Account info, including which namespace this token's paths resolve in."""
         return self._request(f'{API_BASE}/2/users/get_current_account').json()
+
+    def list_folder_cursor(self, path, recursive=False):
+        """The cursor for the current state of `path`, without listing it.
+
+        Used when the caller is about to look at everything anyway, so paging
+        the whole listing just to obtain a cursor would be wasted.
+        """
+        response = self._request(f'{API_BASE}/2/files/list_folder/get_latest_cursor', json_body={
+            'path': _normalize_path(path),
+            'recursive': recursive,
+            'include_deleted': True,
+            'include_media_info': False,
+        })
+        return response.json()['cursor']
+
+    def list_folder_changes(self, cursor):
+        """Return `(entries, cursor)` for everything changed since `cursor`.
+
+        Entries include deletions (`.tag == 'deleted'`), which is how a removed
+        state file or credentials file becomes visible. Raises
+        DropboxCursorReset when Dropbox retires the cursor.
+        """
+        entries = []
+        while True:
+            try:
+                response = self._request(f'{API_BASE}/2/files/list_folder/continue',
+                                         json_body={'cursor': cursor})
+            except DropboxError as e:
+                if e.status_code == 409 and 'reset' in e.summary:
+                    raise DropboxCursorReset(str(e), e.status_code, e.body)
+                raise
+            result = response.json()
+            entries.extend(result.get('entries', []))
+            cursor = result['cursor']
+            if not result.get('has_more'):
+                return entries, cursor
 
     def get_metadata(self, path):
         """Return the entry dict for `path`, or None when it does not exist."""

--- a/functions/main.py
+++ b/functions/main.py
@@ -243,7 +243,7 @@ DROPBOX_INGEST_SECRETS = [
     'DROPBOX_APP_KEY', 'DROPBOX_APP_SECRET', 'DROPBOX_REFRESH_TOKEN',
 ]
 
-def _run_dropbox_ingest(dry_run=False, only_folder=None):
+def _run_dropbox_ingest(dry_run=False, only_folder=None, full_sweep=False):
     """Run the ingest under the shared lock, printing each status line."""
     from dropbox_ingest import run_ingest as run_ingest_fn
     from dropbox_ingest import lock as ingest_lock
@@ -255,7 +255,7 @@ def _run_dropbox_ingest(dry_run=False, only_folder=None):
         return [bit]
     bits = []
     try:
-        for bit in run_ingest_fn(dry_run=dry_run, only_folder=only_folder):
+        for bit in run_ingest_fn(dry_run=dry_run, only_folder=only_folder, full_sweep=full_sweep):
             print(json.dumps(bit, ensure_ascii=False))
             bits.append(bit)
     finally:
@@ -273,5 +273,7 @@ def dropbox_ingest(req: https_fn.Request) -> https_fn.Response:
         return https_fn.Response("Unauthorized", status=401)
     dry_run = req.args.get('dry_run', 'false').lower() == 'true'
     only_folder = req.args.get('folder')
-    bits = _run_dropbox_ingest(dry_run=dry_run, only_folder=only_folder)
+    # `full=true` ignores the stored cursor and visits every folder.
+    full_sweep = req.args.get('full', 'false').lower() == 'true'
+    bits = _run_dropbox_ingest(dry_run=dry_run, only_folder=only_folder, full_sweep=full_sweep)
     return https_fn.Response(json.dumps(bits, ensure_ascii=False), status=200, mimetype='application/json')

--- a/functions/tests/test_dropbox_ingest.py
+++ b/functions/tests/test_dropbox_ingest.py
@@ -21,8 +21,9 @@ from dropbox_ingest import (
     run_ingest, scan_time, upload_scan, write_state, MAX_FILE_ATTEMPTS,
 )
 from dropbox_ingest.dropbox_api import (
-    DropboxClient, DropboxConflict, DropboxError, team_namespace_id,
+    DropboxClient, DropboxConflict, DropboxCursorReset, DropboxError, team_namespace_id,
 )
+from dropbox_ingest import delta
 from dropbox_ingest.images import ImageRejected, crop_to_ratio, prepare_image
 
 NOW = datetime.datetime(2026, 8, 25, 12, 0, 0, tzinfo=datetime.timezone.utc)
@@ -75,7 +76,11 @@ class FakeDropbox:
         self.files = files or {}
         self.uploads = []
         self.rev_counter = 0
-        self.calls = {'list_folder': 0, 'get_metadata': 0, 'download': 0, 'upload': 0}
+        self.calls = {'list_folder': 0, 'get_metadata': 0, 'download': 0, 'upload': 0,
+                      'list_folder_changes': 0, 'list_folder_cursor': 0}
+        self.pending_changes = []       # entries the next delta call reports
+        self.cursor_reset = False
+        self.cursor_counter = 0
 
     def list_folder(self, path, recursive=False):
         self.calls['list_folder'] += 1
@@ -87,6 +92,19 @@ class FakeDropbox:
                 if other != path and other.startswith(prefix):
                     entries.extend(extra)
         return iter(entries)
+
+    def list_folder_cursor(self, path, recursive=False):
+        self.calls['list_folder_cursor'] += 1
+        self.cursor_counter += 1
+        return f'cursor-{self.cursor_counter}'
+
+    def list_folder_changes(self, cursor):
+        self.calls['list_folder_changes'] += 1
+        if self.cursor_reset:
+            raise DropboxCursorReset('reset', 409, {'error_summary': 'reset/...'})
+        changes, self.pending_changes = self.pending_changes, []
+        self.cursor_counter += 1
+        return changes, f'cursor-{self.cursor_counter}'
 
     def get_metadata(self, path):
         self.calls['get_metadata'] += 1
@@ -570,6 +588,12 @@ class FolderFixture:
         return json.loads(self.client.files['/archive/ws/chronomaps.state.json'][0])
 
 
+def warm_tracker(root='/archive', dirty=(), when='2026-08-25T11:59:00Z'):
+    """A tracker that has already swept, so runs take the delta path."""
+    return delta.MemoryTracker({'root': root, 'cursor': 'cursor-0',
+                                'dirty': list(dirty), 'full_sweep_at': when})
+
+
 def upload_session():
     """A requests-like session that names each item after the file it received.
 
@@ -820,39 +844,182 @@ class TestGroupEntries:
 
 
 class TestListingCost:
-    """The point of the single listing: an idle sweep must not scale with folders."""
+    """The point of the delta scheme: an idle sweep must touch almost nothing."""
 
-    def _idle_client(self, folder_count):
+    def _client(self, folder_count):
         folders = [folder_entry(f'/archive/ws-{i}') for i in range(folder_count)]
         entries = {'/archive': folders}
         for folder in folders:
             entries[folder['path_display']] = [file_entry(f"{folder['path_display']}/notes.txt")]
         return FakeDropbox(entries, {})
 
-    def test_idle_sweep_lists_once_regardless_of_folder_count(self):
+    def test_idle_run_touches_nothing(self):
         for folder_count in (5, 40):
-            client = self._idle_client(folder_count)
-            list(run_ingest(settings=make_settings(), client=client, now=NOW))
-            assert client.calls['list_folder'] == 1, f'{folder_count} folders should still be one listing'
+            client = self._client(folder_count)
+            results = list(run_ingest(settings=make_settings(), client=client, now=NOW,
+                                      tracker=warm_tracker()))
+            assert client.calls['list_folder_changes'] == 1
+            assert client.calls['list_folder'] == 0, 'no folder is listed when nothing changed'
             assert client.calls['get_metadata'] == 0
             assert client.calls['download'] == 0
+            assert results[-1]['action'] == 'done' and results[-1]['folders'] == 0
+
+    def test_only_the_changed_folder_is_listed(self):
+        client = self._client(5)
+        client.pending_changes = [file_entry('/archive/ws-3/new.jpg')]
+        list(run_ingest(settings=make_settings(), client=client, now=NOW, tracker=warm_tracker()))
+        # one listing to resolve folder names, one for the folder that changed
+        assert client.calls['list_folder'] == 2
+
+    def test_first_run_sweeps_everything_and_stores_a_cursor(self):
+        client = self._client(3)
+        tracker = delta.MemoryTracker()
+        results = list(run_ingest(settings=make_settings(), client=client, now=NOW, tracker=tracker))
+        sweep = [r for r in results if r['action'] == 'full-sweep']
+        assert sweep and sweep[0]['reason'] == 'first run for this root'
+        assert client.calls['list_folder_cursor'] == 1
+        assert tracker.load()['cursor'] == 'cursor-1'
 
     def test_active_folder_does_not_re_look_up_its_state_file(self):
         state = dict(empty_state('ws-1'), files={'hash-a.jpg': {'item_id': 'x'}})
         fixture = FolderFixture(
             files=[('a.jpg', image_bytes(530, 1000), '2026-08-25T10:00:00Z', '2026-08-25T10:00:20Z')],
             state=state)
-        list(run_ingest(settings=make_settings(), client=fixture.client, now=NOW))
-        # config + state downloads, and no separate metadata lookup for the state file
+        fixture.client.pending_changes = [file_entry('/archive/ws/a.jpg')]
+        list(run_ingest(settings=make_settings(), client=fixture.client, now=NOW,
+                        tracker=warm_tracker()))
         assert fixture.client.calls['get_metadata'] == 0
-        assert fixture.client.calls['download'] == 2
+        assert fixture.client.calls['download'] == 2      # credentials + state
 
     def test_missing_state_file_is_confirmed_before_re_ingesting(self):
         """A stale listing must not be trusted into re-uploading everything."""
         fixture = FolderFixture(
             files=[('a.jpg', image_bytes(530, 1000), '2026-08-25T10:00:00Z', '2026-08-25T10:00:20Z')])
-        list(run_ingest(settings=make_settings(), client=fixture.client, dry_run=True, now=NOW))
+        fixture.client.pending_changes = [file_entry('/archive/ws/a.jpg')]
+        list(run_ingest(settings=make_settings(), client=fixture.client, dry_run=True, now=NOW,
+                        tracker=warm_tracker()))
         assert fixture.client.calls['get_metadata'] == 1
+
+
+class TestDirtyFolders:
+    """A folder stays on the list until a pass leaves nothing behind."""
+
+    def _fixture(self, **kwargs):
+        fixture = FolderFixture(**kwargs)
+        fixture.client.pending_changes = [file_entry('/archive/ws/a.jpg')]
+        return fixture
+
+    def _run(self, fixture, tracker, **kwargs):
+        return list(run_ingest(settings=make_settings(), client=fixture.client, now=NOW,
+                               tracker=tracker, **kwargs))
+
+    def test_clean_pass_clears_the_flag(self):
+        fixture = self._fixture(files=[
+            ('a.jpg', image_bytes(530, 1000), '2026-08-25T10:00:00Z', '2026-08-25T10:00:20Z')])
+        tracker = warm_tracker()
+        self._run(fixture, tracker, session=upload_session())
+        assert tracker.load()['dirty'] == []
+
+    def test_deferred_scan_keeps_the_folder_dirty(self):
+        """The cursor reports a change once; the flag is what brings us back."""
+        fixture = self._fixture(files=[
+            ('a.jpg', image_bytes(530, 1000), '2026-08-25T11:59:50Z', '2026-08-25T11:59:55Z')])
+        tracker = warm_tracker()
+        self._run(fixture, tracker, session=upload_session())
+        assert tracker.load()['dirty'] == ['ws']
+
+        # Next run: the cursor has nothing new, but the flag brings us back and
+        # the scan - now settled - is ingested.
+        fixture.client.pending_changes = []
+        later = NOW + datetime.timedelta(minutes=10)
+        results = list(run_ingest(settings=make_settings(), client=fixture.client, now=later,
+                                  tracker=tracker, session=upload_session()))
+        assert [r for r in results if r['action'] == 'uploaded']
+        assert tracker.load()['dirty'] == []
+
+    def test_capped_folder_stays_dirty(self):
+        fixture = self._fixture(
+            files=[(f'{i}.jpg', image_bytes(530, 1000), f'2026-08-25T10:0{i}:00Z',
+                    f'2026-08-25T10:0{i}:20Z') for i in range(3)],
+            config_text='workspace: ws-1\napi_key: key-1\nmax_uploads_per_run: 2\n')
+        tracker = warm_tracker()
+        self._run(fixture, tracker, session=upload_session())
+        assert tracker.load()['dirty'] == ['ws'], 'the deferred images must not be forgotten'
+
+    def test_failed_upload_keeps_the_folder_dirty(self):
+        fixture = self._fixture(files=[
+            ('a.jpg', image_bytes(530, 1000), '2026-08-25T10:00:00Z', '2026-08-25T10:00:20Z')])
+        session = Mock()
+        session.post.return_value = Mock(status_code=500, text='boom')
+        tracker = warm_tracker()
+        self._run(fixture, tracker, session=session)
+        assert tracker.load()['dirty'] == ['ws']
+
+    def test_skipped_image_does_not_keep_the_folder_dirty(self):
+        """A rejected ratio is a final verdict, not unfinished work."""
+        fixture = self._fixture(files=[
+            ('wide.jpg', image_bytes(1000, 1000), '2026-08-25T10:00:00Z', '2026-08-25T10:00:20Z')])
+        tracker = warm_tracker()
+        self._run(fixture, tracker, session=upload_session())
+        assert tracker.load()['dirty'] == []
+
+    def test_cursor_and_flags_are_persisted_before_any_work(self):
+        """If the cursor advanced but the flags did not, changes would be lost."""
+        fixture = self._fixture(files=[
+            ('a.jpg', image_bytes(530, 1000), '2026-08-25T10:00:00Z', '2026-08-25T10:00:20Z')])
+        tracker = warm_tracker()
+        saved = []
+        original = tracker.save
+        tracker.save = lambda data: (saved.append(dict(data)), original(data))[1]
+
+        session = Mock()
+        session.post.side_effect = RuntimeError('died mid-run')
+        self._run(fixture, tracker, session=session)
+
+        assert saved[0]['dirty'] == ['ws'], 'flag stored before the upload was attempted'
+        assert saved[0]['cursor'] == 'cursor-1'
+        assert tracker.load()['dirty'] == ['ws'], 'and still set after the failure'
+
+    def test_dry_run_does_not_persist(self):
+        fixture = self._fixture(files=[
+            ('a.jpg', image_bytes(530, 1000), '2026-08-25T10:00:00Z', '2026-08-25T10:00:20Z')])
+        tracker = warm_tracker()
+        self._run(fixture, tracker, dry_run=True)
+        assert tracker.load()['cursor'] == 'cursor-0', 'cursor untouched'
+        assert tracker.load()['dirty'] == []
+
+    def test_cursor_reset_falls_back_to_a_full_sweep(self):
+        fixture = self._fixture(files=[
+            ('a.jpg', image_bytes(530, 1000), '2026-08-25T10:00:00Z', '2026-08-25T10:00:20Z')])
+        fixture.client.cursor_reset = True
+        tracker = warm_tracker()
+        results = self._run(fixture, tracker, session=upload_session())
+        sweep = [r for r in results if r['action'] == 'full-sweep']
+        assert sweep and sweep[0]['reason'] == 'cursor reset by Dropbox'
+        assert [r for r in results if r['action'] == 'uploaded']
+
+    def test_changing_the_root_forces_a_full_sweep(self):
+        fixture = self._fixture(files=[
+            ('a.jpg', image_bytes(530, 1000), '2026-08-25T10:00:00Z', '2026-08-25T10:00:20Z')])
+        tracker = warm_tracker(root='/somewhere-else')
+        results = self._run(fixture, tracker, session=upload_session())
+        assert [r for r in results if r['action'] == 'full-sweep'][0]['reason'] == 'first run for this root'
+        assert tracker.load()['root'] == '/archive'
+
+    def test_periodic_sweep_re_marks_everything(self):
+        fixture = self._fixture(files=[
+            ('a.jpg', image_bytes(530, 1000), '2026-08-25T10:00:00Z', '2026-08-25T10:00:20Z')])
+        stale = warm_tracker(when='2026-08-24T00:00:00Z')      # older than the interval
+        results = self._run(fixture, stale, session=upload_session())
+        assert [r for r in results if r['action'] == 'full-sweep'][0]['reason'] == 'periodic full sweep'
+        assert stale.load()['full_sweep_at'] == '2026-08-25T12:00:00Z'
+
+    def test_deleted_folder_is_forgotten(self):
+        client = FakeDropbox({'/archive': []}, {})
+        tracker = warm_tracker(dirty=['gone'])
+        results = list(run_ingest(settings=make_settings(), client=client, now=NOW, tracker=tracker))
+        assert [r for r in results if r['action'] == 'forgotten']
+        assert tracker.load()['dirty'] == []
 
 
 class TestRunIngest:
@@ -866,7 +1033,8 @@ class TestRunIngest:
             '/archive/broken/chronomaps.config': (b'workspace: ws\napi_key: k\nratio: 0,53\n', 'r'),
             '/archive/ok/chronomaps.config': (b'workspace: ws-ok\napi_key: k\n', 'r'),
         })
-        results = list(run_ingest(settings=make_settings(), client=client, dry_run=True, now=NOW))
+        results = list(run_ingest(settings=make_settings(), client=client, dry_run=True, now=NOW,
+                                  tracker=delta.MemoryTracker()))
         assert [r for r in results if r['action'] == 'skip-folder' and 'bad credentials' in r['reason']]
         assert [r for r in results if r.get('workspace') == 'ws-ok']
         assert results[-1]['action'] == 'done'
@@ -875,7 +1043,8 @@ class TestRunIngest:
         folders = [folder_entry(f'/archive/ws{i}') for i in range(3)]
         client = FakeDropbox({'/archive': folders}, {})
         settings = make_settings(run_deadline_seconds=-1)
-        results = list(run_ingest(settings=settings, client=client, dry_run=True, now=NOW))
+        results = list(run_ingest(settings=settings, client=client, dry_run=True, now=NOW,
+                                  tracker=delta.MemoryTracker()))
         deadline = [r for r in results if r['action'] == 'deadline']
         assert deadline and deadline[0]['deferred'] == 3
 
@@ -895,6 +1064,7 @@ class TestRunIngest:
             '/archive/ok': [],
         }, {'/archive/broken/chronomaps.config': (b'workspace: ws\napi_key: k\n', 'r')})
         client.files['/archive/broken/chronomaps.state.json'] = (b'{corrupt', 'r')
-        results = list(run_ingest(settings=make_settings(), client=client, now=NOW))
+        results = list(run_ingest(settings=make_settings(), client=client, now=NOW,
+                                  tracker=delta.MemoryTracker()))
         assert [r for r in results if r['action'] == 'error']
         assert results[-1]['action'] == 'done'


### PR DESCRIPTION
Reopens #29, which GitHub auto-closed when its base branch was deleted on merging #28. Same commit, rebased onto main.

| | before | #28 | this |
|---|---|---|---|
| idle sweep | ~50s / 43 calls | 8.8s / 8 calls | **1.4s / 1 call** |
| full sweep | ~50s / 43 calls | 8.8s / 8 calls | ~10s / 11 calls (every 6h) |

## The design

Dropbox's `list_folder/continue` cursor reports what changed since the previous run. The obvious use — process exactly the changed entries — has a trap: **the cursor reports each change exactly once**. A scan still inside the settle window would be seen once, skipped as too fresh, and never mentioned again. That would need a persisted per-file pending set, where any bug loses scans silently.

Instead the cursor only marks folders **dirty**, and a folder stays dirty until a pass over it leaves nothing behind:

- nothing deferred by the settle window,
- no `capped` remainder from `max_uploads_per_run`,
- no per-file errors,
- no deadline cut-off.

Per-folder state instead of per-file bookkeeping, the listing still always comes fresh from the folder, and `process_folder` is untouched — the delta only decides which folders to visit.

## Correctness details worth checking in review

- **Cursor and dirty set are one Firestore document, written together before any uploading.** A cursor that advanced without its flags would lose those changes permanently. `test_cursor_and_flags_are_persisted_before_any_work` kills a run mid-upload and asserts the flag survives.
- **Any change dirties a folder**, not just images — a credentials file appearing enables a folder full of existing scans, and deleting `chronomaps.state.json` is how you force a re-upload.
- **Our own state-file write re-dirties the folder.** Self-terminating: the next run lists it, finds nothing, clears the flag.
- **Self-healing.** The failure mode of a delta scheme is silence, so every `DROPBOX_FULL_SWEEP_HOURS` (default 6) — plus first run, changed root, and a retired cursor — every folder is re-marked.
- **The CLI keeps its own in-memory tracker**, so a manual run never disturbs the deployed function's cursor.

## Tests

93 pass (13 new). `TestDirtyFolders` covers what the flag exists for: a deferred scan keeps the folder dirty and is ingested next run, capped and failed passes stay dirty, a rejected aspect ratio does not, dry runs persist nothing, cursor reset and root change fall back to a sweep, the periodic sweep fires, and a deleted folder is forgotten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hdp8CFMcmfFTeQnmK15Aup
