### PR TITLE
Fix TestUseItem: give the items a created_at

### DIFF
--- a/functions/tests/test_taxonomy.py
+++ b/functions/tests/test_taxonomy.py
@@ -116,24 +116,62 @@ class TestGenerateEmbedding:
 
 
 class TestUseItem:
+    """`use_item` decides which items reach clustering and taxonomy.
+
+    Each case carries the fields it is *not* testing, so a failure points at the
+    rule under test instead of at an incidentally missing field. That is what
+    went wrong before: these cases omitted `created_at`, so when it became
+    required they failed for a reason none of them was about.
+    """
+
+    COMPLETE = {
+        'favorable_future': 'yes',
+        'future_scenario_description': 'desc',
+        'created_at': '2026-01-01T00:00:00Z',
+    }
+
+    def item(self, **overrides):
+        """A usable item, with fields overridden or (on None) removed."""
+        item = dict(self.COMPLETE)
+        for field, value in overrides.items():
+            if value is None:
+                item.pop(field, None)
+            else:
+                item[field] = value
+        return item
+
+    def test_accepts_a_complete_item(self):
+        from shared import use_item
+        assert use_item(self.COMPLETE) is True
+
     def test_requires_favorable_future_by_default(self):
         from shared import use_item
-        assert use_item({'future_scenario_description': 'desc'}) is False
+        assert use_item(self.item(favorable_future=None)) is False
 
     def test_accepts_valid_favorable_future(self):
         from shared import use_item
-        assert use_item({'favorable_future': 'yes', 'future_scenario_description': 'desc'}) is True
-        assert use_item({'favorable_future': 'prevent', 'future_scenario_description': 'desc'}) is True
-        assert use_item({'favorable_future': 'mostly_prefer', 'future_scenario_description': 'desc'}) is True
+        for value in ('yes', 'prevent', 'mostly_prefer'):
+            assert use_item(self.item(favorable_future=value)) is True, value
+
+    def test_rejects_unrecognised_favorable_future(self):
+        from shared import use_item
+        assert use_item(self.item(favorable_future='maybe')) is False
 
     def test_skips_favorable_future_check_when_not_required(self):
         from shared import use_item
-        assert use_item({'future_scenario_description': 'desc'}, favorable_future_required=False) is True
+        assert use_item(self.item(favorable_future=None), favorable_future_required=False) is True
 
     def test_requires_description_always(self):
         from shared import use_item
-        assert use_item({'favorable_future': 'yes'}, favorable_future_required=False) is False
+        assert use_item(self.item(future_scenario_description=None), favorable_future_required=False) is False
+        assert use_item(self.item(future_scenario_description=''), favorable_future_required=False) is False
         assert use_item({}, favorable_future_required=False) is False
+
+    def test_requires_created_at(self):
+        """Added in 1898c8c, and until now untested: no timestamp, no item."""
+        from shared import use_item
+        assert use_item(self.item(created_at=None)) is False
+        assert use_item(self.item(created_at=None), favorable_future_required=False) is False
 
 
 # --- Tests for taxonomy.naming ---


### PR DESCRIPTION
CI has failed on every run since 2026-08-04 — always the same two `TestUseItem` cases, and never for a reason either test was about.

## Cause

`1898c8c "Add 'created_at' to use_item"` added this to `functions/shared/__init__.py:17`:

```python
if item.get('created_at') is None:
    return False
```

The tests built items without `created_at`, so from that commit on they returned `False` — not because the favorable_future rule they were checking had changed, but because of a field neither case mentioned.

## Fix

Each case now carries the fields it is *not* testing, via a `COMPLETE` item and an `item(**overrides)` helper where `None` removes a field. A failure now points at the rule under test.

That is the real defect here: the old cases were specific about one field and silent about the rest, which is both why a new requirement broke them and why nothing covered the new rule. So this also adds:

- `test_requires_created_at` — the rule from `1898c8c`, until now untested
- `test_rejects_unrecognised_favorable_future` — the `any(x in …)` branch
- `test_accepts_a_complete_item` — the baseline the others vary from

No production code is touched; the `created_at` requirement is left exactly as `1898c8c` intended. Worth knowing separately: that rule means any item without a timestamp is excluded from clustering and taxonomy, which is now visible in a test rather than implicit.

**Full suite: 285 passed, 0 failed** — green for the first time in over two weeks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hdp8CFMcmfFTeQnmK15Aup
