### PR TITLE
Poll Dropbox every minute and settle scans after 30s

### DIFF
--- a/functions/.env.chronomaps3
+++ b/functions/.env.chronomaps3
@@ -9,6 +9,11 @@ DROPBOX_ROOT_PATH=/futuring_workshops_archive
 # Folders whose oldest content predates this are treated as pre-existing.
 DROPBOX_FOLDER_CUTOFF=2026-08-20T00:00:00Z
 
+# How long a file must sit untouched before it is considered done syncing.
+# Shorter than the 180s default so a scan reaches the map sooner; pages that
+# arrive after their batch was ingested still rejoin it (see assign_batches).
+DROPBOX_SETTLE_SECONDS=30
+
 # Set only for a Dropbox Business team space; `scripts/dropbox_check.py` prints
 # the value to use when it is needed.
 # DROPBOX_NAMESPACE_ID=

--- a/functions/main.py
+++ b/functions/main.py
@@ -262,7 +262,7 @@ def _run_dropbox_ingest(dry_run=False, only_folder=None, full_sweep=False):
         ingest_lock.release(holder)
     return bits
 
-@scheduler_fn.on_schedule(region='europe-west1', schedule="every 5 minutes", secrets=DROPBOX_INGEST_SECRETS, memory=options.MemoryOption.GB_2, timeout_sec=1800)
+@scheduler_fn.on_schedule(region='europe-west1', schedule="every 1 minutes", secrets=DROPBOX_INGEST_SECRETS, memory=options.MemoryOption.GB_2, timeout_sec=1800)
 def dropbox_ingest_scheduled(event: scheduler_fn.ScheduledEvent) -> None:
     print("STARTING dropbox ingest")
     _run_dropbox_ingest()


### PR DESCRIPTION
Scans currently wait up to 5 minutes for the next poll **plus** 3 minutes of settle time before they reach the map. This drops both.

| | before | after |
|---|---|---|
| `dropbox_ingest_scheduled` schedule | `every 5 minutes` | `every 1 minutes` |
| settle window | 180s (default) | 30s (`DROPBOX_SETTLE_SECONDS`) |

The settle window goes in `.env.chronomaps3` rather than changing `DEFAULT_SETTLE_SECONDS`, since `load_settings` already reads it from the deployed env (`dropbox_ingest/__init__.py:122`) and that file is where the project's non-secret config lives. Verified: `load_settings` returns 180 without it, 30 with it.

## Why this is safe

**Overlapping runs.** The function has `timeout_sec=1800`, so at a 1-minute cadence most invocations will land while a previous one is still going. `_run_dropbox_ingest` already handles this — it takes a Firestore lease and returns `{'action': 'skipped', 'reason': 'another dropbox ingest run holds the lock'}` when it can't. So the extra invocations cost one transaction each.

**Batching.** A shorter settle window means a multi-page scan can be ingested before every page has synced — which is what the window exists to prevent. But `assign_batches` matches each page against a window of *persisted recent* batches, not just the latest one, and its docstring is explicit: *"a page of A that syncs an hour late still rejoins A instead of being glued onto B."* Late pages rejoin their batch by scan time, within `batch_gap_seconds` (120s), which is unchanged.

93 dropbox ingest tests pass; they construct `Settings(settle_seconds=180)` explicitly, so they're unaffected by the env default.

## Note

Merging redeploys all functions. The `cluster_its_time` backfill chain is mid-drain right now — worth waiting for it to finish, or merging in the gap between its runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EA7fGjaAmtdztg2F6nxSXi