### PR TITLE
Pin batch_gap_seconds in the ingest fixture, and pin the defaults themselves

### DIFF
--- a/functions/tests/test_dropbox_ingest.py
+++ b/functions/tests/test_dropbox_ingest.py
@@ -19,6 +19,7 @@ from dropbox_ingest import (
     derive_handler_url, empty_state, entry_key, find_config_entry, folder_created_at,
     is_known, merge_batches, merge_states, parse_credentials, process_folder, read_state,
     run_ingest, scan_time, upload_scan, write_state, MAX_FILE_ATTEMPTS,
+    DEFAULT_BATCH_GAP_SECONDS, DEFAULT_MAX_UPLOADS_PER_RUN,
 )
 from dropbox_ingest.dropbox_api import (
     DropboxClient, DropboxConflict, DropboxCursorReset, DropboxError, team_namespace_id,
@@ -161,6 +162,20 @@ class TestParseCredentials:
         assert config.max_uploads_per_run == 5
         assert config.time_source == 'server'
         assert config.rotate_landscape == 'cw'
+
+    def test_defaults_when_the_file_only_names_the_workspace(self):
+        """Pins the shipped defaults so changing one is a deliberate edit here.
+
+        These reach every folder that does not override them, and the batching
+        ones decide whether a person's pages become one author or several.
+        """
+        config = parse_credentials('workspace: ws\napi_key: key\n')
+        assert config.enabled is True
+        assert config.ignore_cutoff is False
+        assert config.batch_gap_seconds == DEFAULT_BATCH_GAP_SECONDS
+        assert config.max_uploads_per_run == DEFAULT_MAX_UPLOADS_PER_RUN
+        assert config.time_source == 'auto'
+        assert config.rotate_landscape == 'off'
 
     def test_missing_fields_rejected(self):
         with pytest.raises(ConfigurationError):
@@ -562,8 +577,14 @@ class TestUploadScan:
 class FolderFixture:
     """A Dropbox folder with a credentials file and a few scans."""
 
-    def __init__(self, files=(), config_text='workspace: ws-1\napi_key: key-1\n',
+    # batch_gap_seconds is pinned so these cases test the batching rule rather
+    # than whatever DEFAULT_BATCH_GAP_SECONDS happens to be; a test that cares
+    # about the default passes its own config_text.
+    DEFAULT_CONFIG_TEXT = 'workspace: ws-1\napi_key: key-1\nbatch_gap_seconds: 120\n'
+
+    def __init__(self, files=(), config_text=None,
                  created='2026-08-24T09:00:00Z', state=None):
+        config_text = config_text if config_text is not None else self.DEFAULT_CONFIG_TEXT
         self.folder = folder_entry('/archive/ws')
         entries = [file_entry('/archive/ws/chronomaps.config', server_modified=created)]
         stored = {'/archive/ws/chronomaps.config': (config_text.encode(), 'rev-config')}


### PR DESCRIPTION
CI went red on `05ab148 "Better timeouts"`, not on #34 — it was already failing on `05ab148` and on `a92dc2a` before my merge landed on top.

That commit changed two defaults:

```diff
-DEFAULT_SETTLE_SECONDS = 180      # let a multi-page scan finish syncing before batching it
-DEFAULT_BATCH_GAP_SECONDS = 120   # a gap longer than this starts a new author batch
+DEFAULT_SETTLE_SECONDS = 30
+DEFAULT_BATCH_GAP_SECONDS = 5
```

`FolderFixture` pins `settle_seconds` but never pinned `batch_gap_seconds`, so it fell through to the default. Two cases feed pages 20–60s apart and assert they share an author; at a 5s gap each page starts its own batch:

```
test_uploads_new_scans_and_records_state  - same batch shares an author:      assert 2 == 1
test_batch_history_is_persisted_per_chunk - only the batch actually processed: assert 4 == 1
```

## The fix

Those cases are about the batching *rule*, not about whatever value ships as the default, so the fixture now pins `batch_gap_seconds` the way it already pins `settle_seconds`. Same lesson as #31: each case carries the fields it is not testing, so a failure points at the rule under test.

Pinning alone would just hide the next change of this kind, so `TestParseCredentials` now asserts the defaults directly. Changing one is a deliberate edit to a test that explains what it guards, instead of a surprise in two unrelated cases.

299 tests pass.

## One question on `05ab148`, not addressed here

Cutting `DEFAULT_SETTLE_SECONDS` to 30 matches `DROPBOX_SETTLE_SECONDS=30` already deployed via `.env.chronomaps3`, so code and deployment now agree — good.

`DEFAULT_BATCH_GAP_SECONDS` 120 → 5 is a different kind of change: it isn't a timeout, it decides whether one person's pages become a single author batch or several. Anything scanned more than 5 seconds apart now gets its own `author_id`. That's deliberate-looking but large, and this PR does not change it — I've only stopped it from breaking tests that were asserting something else.

Worth confirming it's what you want. If it is, `assign_batches`' own tests should probably gain a case at the new value so the intent is recorded. (I looked for evidence in the one folder ingested since — 71 items landed as one 69-page batch plus two singletons — but those timestamps are upload times, not the Dropbox scan times batching actually uses, so they don't answer it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EA7fGjaAmtdztg2F6nxSXi