### PR TITLE
Draw too-small workspaces as one central block instead of skipping them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ progress.
 ## Tests
 
 ```bash
-cd functions && pytest tests/          # 298 tests, ~20s, no cloud access needed
+cd functions && pytest tests/          # 313 tests, ~20s, no cloud access needed
 ```
 
 Config in `functions/pytest.ini`; CI installs `functions/requirements-test.txt`. Coverage is
@@ -62,11 +62,15 @@ JSONs are uploaded then `make_public()`d — objects are individually public, th
 not, so a **missing** object returns 404 and a **non-public** one returns 403. That
 distinction is the fastest way to tell "never generated" from "ACL problem".
 
-An item only reaches a map if `shared.use_item` accepts it, and a workspace with fewer than
-10 accepted records writes nothing at all — its map 404s forever. `use_item` needs a
-description, a `created_at`, and a favorability; `shared.resolve_favorable_future` takes the
-human answer (`favorable_future`) first and falls back to the model's
-(`ai_favorable_future`), so check both before concluding an item is unusable.
+An item only reaches a map if `shared.use_item` accepts it. A workspace with **no** accepted
+records writes nothing at all — its map 404s forever. One with fewer than
+`TSNEParams.MIN_TSNE_RECORDS` (10) skips t-SNE and is drawn as one block in the middle of the
+grid under a single "future screenshots" cluster (`calc_tsne.fallback_grid`), so a small map
+still renders. `use_item` needs a description, a `created_at`, and a favorability;
+`shared.resolve_favorable_future` takes the human answer (`favorable_future`) first and falls
+back to the model's (`ai_favorable_future`), so check both before concluding an item is
+unusable. Either way `ensure_analysis` backfills embeddings and `ai_favorable_future` /
+`ai_plausibility` for every fetched item *before* the count is checked.
 
 `if_changed=True` skips a workspace whose record set is unchanged, but the hash is over
 record **ids** only — editing an existing item does not trigger a rebuild.

--- a/functions/cluster_screenshots/__init__.py
+++ b/functions/cluster_screenshots/__init__.py
@@ -254,7 +254,8 @@ def cluster_screenshots(config, tag=None, add_title=True, if_changed=False):
                 info = msg['info']
                 records = msg['records']
                 grid = msg['grid']
-                if len(records) > 0:
+                # A too-small workspace arrives with its single cluster already set.
+                if len(records) > 0 and 'clusters' not in info:
                     yield from find_clusters(records, grid, info)
 
                 convert_all_coords(info)

--- a/functions/cluster_screenshots/calc_tsne.py
+++ b/functions/cluster_screenshots/calc_tsne.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import math
 from pathlib import Path
 import datetime
 
@@ -25,6 +26,15 @@ from shared import (use_item, EMBEDDING_DIMENSION,
                     resolve_favorable_future, resolve_plausibility)
 
 FONT = Path(__file__).with_name('SourceSans.ttf')
+
+# Title of the single cluster a too-small workspace is drawn as, in the same
+# shape extract_cluster_title returns.
+FALLBACK_CLUSTER_TITLE = dict(
+    english='future screenshots',
+    dutch='toekomstige screenshots',
+    hebrew='צילומי מסך מהעתיד',
+    arabic='لقطات شاشة من المستقبل',
+)
 
 def load_records(config, records, params: TSNEParams):
     if len(config) > 1:
@@ -168,6 +178,40 @@ def calc_tsne_grid(X_2d, out_dim):
     _, col_asses, _ = lapjv(cost_matrix)
     grid_jv = grid[col_asses]
     return grid_jv
+
+def fallback_grid(count, out_dim):
+    """Pack `count` cells into one compact block at the centre of the grid.
+
+    Stands in for generate_tsne + calc_tsne_grid when there are too few records
+    for t-SNE, and returns the same shape they do: (count, 2) fractions of
+    (y, x) in [0, 1], one row per record.
+    """
+    cols = max(1, min(out_dim[0], math.ceil(math.sqrt(count))))
+    rows = math.ceil(count / cols)
+    x0 = (out_dim[0] - cols) // 2
+    y0 = (out_dim[1] - rows) // 2
+    span_x = max(out_dim[0] - 1, 1)
+    span_y = max(out_dim[1] - 1, 1)
+    cells = [
+        ((y0 + i // cols) / span_y, (x0 + i % cols) / span_x)
+        for i in range(count)
+    ]
+    return np.array(cells, dtype=np.float64).reshape(-1, 2)
+
+def single_cluster(info, title):
+    """One cluster spanning every image on the grid, shaped like find_clusters' output."""
+    positions = [g['pos'] for g in info['grid']]
+    if not positions:
+        return []
+    rotations = [g['metadata'].get('rotate', 0) for g in info['grid']]
+    return [dict(
+        title=title,
+        bounds=[
+            [min(p[0] for p in positions), min(p[1] for p in positions)],
+            [max(p[0] for p in positions) + 1, max(p[1] for p in positions) + 1],
+        ],
+        average_rotation=sum(rotations) / len(rotations),
+    )]
 
 def gray_world(im: Image.Image) -> Image.Image:
     """
@@ -375,26 +419,33 @@ def convert_all_coords(info):
 
 def cluster_screenshots_inner(config, params: TSNEParams, last_state_hash=None):
     records = []
+    # load_records also backfills every fetched item's embedding and AI
+    # favorability/plausibility, so by here that is done regardless of how
+    # many records there are; the count only decides the layout below.
     yield from load_records(config, records, params)
     records = records[:params.TO_PLOT]
-    if len(records) < 10:
-        yield dict(msg='Not enough records found.')
+    if len(records) == 0:
+        yield dict(msg='No records found.')
         return
-    yield dict(msg=f'GOT {len(records)} - top record {records[0]["_id"]} created at {records[0]["created_at"] if records else "N/A"}')
+    yield dict(msg=f'GOT {len(records)} - top record {records[0]["_id"]} created at {records[0]["created_at"]}')
     new_state_hash = '|'.join([rec['_id'] for rec in records])
     new_state_hash = hashlib.md5(new_state_hash.encode('utf-8')).hexdigest()
     if last_state_hash and last_state_hash == new_state_hash:
         yield dict(msg=f'No new records - same hash ({last_state_hash} == {new_state_hash})')
         return
 
-    records, activations = records, [rec['embedding'] for rec in records]
-
-    yield dict(msg=f'Generating 2D representation from {len(records)} records.')
-    X_2d = generate_tsne(activations, perplexity=min(params.PERPLEXITY, len(records)-1), tsne_iter=params.TSNE_ITER)
-    yield dict(msg="Generating image grid (%dx%d, %d images" % (params.OUT_DIM[0], params.OUT_DIM[1], len(records)))
-    grid = calc_tsne_grid(X_2d, params.OUT_DIM)
-    grid = grid[:len(records)]
-    yield dict(msg=f"Got grid, X_2d.shape: {X_2d.shape}, grid shape: {grid.shape}")
+    too_few_for_tsne = len(records) < params.MIN_TSNE_RECORDS
+    if too_few_for_tsne:
+        yield dict(msg=f'Only {len(records)} records - too few for t-SNE, packing them into one cluster in the middle.')
+        grid = fallback_grid(len(records), params.OUT_DIM)
+    else:
+        activations = [rec['embedding'] for rec in records]
+        yield dict(msg=f'Generating 2D representation from {len(records)} records.')
+        X_2d = generate_tsne(activations, perplexity=min(params.PERPLEXITY, len(records)-1), tsne_iter=params.TSNE_ITER)
+        yield dict(msg="Generating image grid (%dx%d, %d images" % (params.OUT_DIM[0], params.OUT_DIM[1], len(records)))
+        grid = calc_tsne_grid(X_2d, params.OUT_DIM)
+        grid = grid[:len(records)]
+        yield dict(msg=f"Got grid, X_2d.shape: {X_2d.shape}, grid shape: {grid.shape}")
 
     try:
         # w, h = 530, 1000
@@ -419,6 +470,10 @@ def cluster_screenshots_inner(config, params: TSNEParams, last_state_hash=None):
         yield from create_tsne_image(grid, records, params.OUT_DIM, res, offset, padding, pos_offset, tsne, params)
         image, info = tsne['image'], tsne['info']
         yield dict(msg=f'Got TSNE Image: {image.shape} {image.dtype}')
+        if too_few_for_tsne:
+            # Pre-empts find_clusters downstream, which would try to split
+            # this handful into several clusters and title each with the LLM.
+            info['clusters'] = single_cluster(info, FALLBACK_CLUSTER_TITLE)
         image = Image.fromarray(image)
         if not params.LOCAL:
             yield dict(msg="Creating tiles.")

--- a/functions/cluster_screenshots/tsne_params.py
+++ b/functions/cluster_screenshots/tsne_params.py
@@ -22,6 +22,9 @@ class TSNEParams():
     # Max favorability backfills per workspace per run; the rest wait for the
     # next run rather than pushing the job past its request timeout.
     ANALYSIS_BACKFILL_LIMIT: int = 50
+    # Below this many records t-SNE is meaningless (and perplexity collapses),
+    # so the map is drawn as one block in the middle instead of skipped.
+    MIN_TSNE_RECORDS: int = 10
 
     OPENAI_KEY: str = None
     CHRONOMAPS_API_URL: str = None

--- a/functions/tests/test_cluster_screenshots.py
+++ b/functions/tests/test_cluster_screenshots.py
@@ -1,0 +1,195 @@
+"""
+Tests for the clustering pipeline's small-workspace fallback.
+
+Workspaces with too few records for t-SNE are drawn as one block in the
+middle of the map, under a single 'future screenshots' cluster, instead of
+being skipped.
+"""
+
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from cluster_screenshots import calc_tsne
+from cluster_screenshots.calc_tsne import (
+    FALLBACK_CLUSTER_TITLE, cluster_screenshots_inner, fallback_grid, single_cluster,
+)
+from cluster_screenshots.tsne_params import TSNEParams
+
+
+def _cells(grid, out_dim):
+    """Grid fractions -> integer (x, y) cells, the way create_tsne_image rounds them."""
+    return [
+        (round(pos[1] * (out_dim[0] - 1)), round(pos[0] * (out_dim[1] - 1)))
+        for pos in grid
+    ]
+
+
+class TestFallbackGrid:
+    def test_shape_matches_calc_tsne_grid(self):
+        grid = fallback_grid(5, (23, 20))
+        assert grid.shape == (5, 2)
+        assert grid.min() >= 0 and grid.max() <= 1
+
+    def test_cells_are_distinct_and_contiguous(self):
+        out_dim = (23, 20)
+        cells = _cells(fallback_grid(7, out_dim), out_dim)
+        assert len(set(cells)) == 7
+        xs = sorted({x for x, _ in cells})
+        ys = sorted({y for _, y in cells})
+        assert xs == list(range(xs[0], xs[-1] + 1))
+        assert ys == list(range(ys[0], ys[-1] + 1))
+
+    def test_block_sits_in_the_middle(self):
+        out_dim = (23, 20)
+        cells = _cells(fallback_grid(9, out_dim), out_dim)
+        xs = [x for x, _ in cells]
+        ys = [y for _, y in cells]
+        assert (min(xs), max(xs)) == (10, 12)
+        assert (min(ys), max(ys)) == (8, 10)
+
+    def test_single_record_lands_centre(self):
+        out_dim = (23, 20)
+        assert _cells(fallback_grid(1, out_dim), out_dim) == [(11, 9)]
+
+    def test_zero_records(self):
+        assert fallback_grid(0, (23, 20)).shape == (0, 2)
+
+
+class TestSingleCluster:
+    def test_spans_every_grid_entry(self):
+        info = dict(grid=[
+            dict(pos=[10, 8], id='a', metadata=dict(rotate=10)),
+            dict(pos=[11.5, 8], id='b', metadata=dict(rotate=-4)),
+            dict(pos=[10, 9], id='c', metadata={}),
+        ])
+        clusters = single_cluster(info, FALLBACK_CLUSTER_TITLE)
+        assert len(clusters) == 1
+        cluster = clusters[0]
+        assert cluster['title']['english'] == 'future screenshots'
+        assert cluster['bounds'] == [[10, 8], [12.5, 10]]
+        assert cluster['average_rotation'] == pytest.approx(2)
+
+    def test_empty_grid_gives_no_cluster(self):
+        assert single_cluster(dict(grid=[]), FALLBACK_CLUSTER_TITLE) == []
+
+
+def _fake_records(count):
+    # No screenshot_url, so get_image draws the bundled placeholder instead of
+    # fetching anything.
+    return [
+        dict(_id=f'rec{i}', created_at=f'2025-01-{i + 1:02d}', embedding=[float(i)] * 4,
+             future_scenario_description=f'scenario {i}')
+        for i in range(count)
+    ]
+
+
+def _small_params():
+    # A small grid keeps the rendered image tiny; SIDE sets the pixel scale.
+    return TSNEParams(OUT_DIM_X=6, SIDE=120, MIN_TSNE_RECORDS=10)
+
+
+def _run(records, params):
+    def load(config, out, params):
+        out.extend(records)
+        yield dict(msg='loaded')
+
+    actions = {}
+    with patch.object(calc_tsne, 'load_records', load):
+        for msg in cluster_screenshots_inner([], params):
+            if 'action' in msg:
+                actions[msg['action']] = msg
+    return actions
+
+
+class TestClusterScreenshotsInnerFallback:
+    def test_too_few_records_still_produce_a_map(self):
+        params = _small_params()
+        with patch.object(calc_tsne, 'generate_tsne', side_effect=AssertionError('t-SNE must not run')), \
+             patch.object(calc_tsne, 'calc_tsne_grid', side_effect=AssertionError('lapjv must not run')):
+            actions = _run(_fake_records(5), params)
+
+        assert 'tiles' in actions
+        info = actions['clusters']['info']
+        assert {g['id'] for g in info['grid']} == {f'rec{i}' for i in range(5)}
+        assert info['clusters'] == single_cluster(info, FALLBACK_CLUSTER_TITLE)
+        assert info['clusters'][0]['title'] == FALLBACK_CLUSTER_TITLE
+
+    def test_fallback_block_is_centred_on_the_map(self):
+        params = _small_params()
+        actions = _run(_fake_records(4), params)
+        info = actions['clusters']['info']
+        xs = [int(g['pos'][0]) for g in info['grid']]
+        ys = [int(g['pos'][1]) for g in info['grid']]
+        # 6 x 5 grid: a 2x2 block sits at columns 2-3, rows 1-2.
+        assert params.OUT_DIM == (6, 5)
+        assert (min(xs), max(xs)) == (2, 3)
+        assert (min(ys), max(ys)) == (1, 2)
+
+    def test_no_records_writes_nothing(self):
+        actions = _run([], _small_params())
+        assert actions == {}
+
+    def test_unchanged_records_are_skipped_before_the_fallback(self):
+        records = _fake_records(3)
+        params = _small_params()
+        first = _run(records, params)
+        state_hash = first['clusters']['info']['state_hash']
+
+        def load(config, out, params):
+            out.extend(records)
+            yield dict(msg='loaded')
+
+        with patch.object(calc_tsne, 'load_records', load):
+            actions = [m for m in cluster_screenshots_inner([], params, last_state_hash=state_hash) if 'action' in m]
+        assert actions == []
+
+    def test_enough_records_take_the_tsne_path(self):
+        params = _small_params()
+        records = _fake_records(10)
+        fake_2d = np.zeros((10, 2))
+
+        with patch.object(calc_tsne, 'generate_tsne', return_value=fake_2d) as tsne, \
+             patch.object(calc_tsne, 'calc_tsne_grid', return_value=fallback_grid(10, params.OUT_DIM)) as lap:
+            actions = _run(records, params)
+
+        tsne.assert_called_once()
+        lap.assert_called_once()
+        # Clustering and titling are left to find_clusters downstream.
+        assert 'clusters' not in actions['clusters']['info']
+
+
+class TestAnalysisRunsRegardlessOfCount:
+    """Embeddings and AI favorability/plausibility are backfilled for every
+    fetched item, before the count decides whether t-SNE or the fallback runs."""
+
+    def _load(self, items, params):
+        def fake_get(url, req_params=None, headers=None):
+            resp = type('Resp', (), {})()
+            resp.json = (lambda: items) if url.endswith('/items') else (lambda: dict(title='WS'))
+            return resp
+
+        records = []
+        with patch.object(calc_tsne.requests, 'get', fake_get), \
+             patch.object(calc_tsne, 'ensure_analysis') as ensure:
+            ensure.return_value = iter(())
+            list(calc_tsne.load_records([('ws', 'key')], records, params))
+        return ensure, records
+
+    def test_few_items_are_still_analysed(self):
+        items = [dict(_id=f'r{i}', created_at=f'2025-01-0{i + 1}',
+                      future_scenario_description=f'd{i}') for i in range(3)]
+        ensure, _ = self._load(items, _small_params())
+        ensure.assert_called_once()
+        assert ensure.call_args.args[0] is items
+        assert len(ensure.call_args.args[0]) == 3
+
+    def test_items_the_map_rejects_are_still_analysed(self):
+        # No favorability and no created_at: use_item drops them from the map,
+        # but they are exactly the items the backfill exists for.
+        items = [dict(_id='r0', future_scenario_description='d0')]
+        ensure, records = self._load(items, _small_params())
+        ensure.assert_called_once()
+        assert ensure.call_args.args[0] is items
+        assert records == []


### PR DESCRIPTION
## What

Workspaces with fewer than 10 usable records used to write nothing, so their maps 404'd forever. They now render: t-SNE is skipped and the records are packed into a compact block at the centre of the grid, under a single **"future screenshots"** cluster (title given in all four languages the title extractor normally returns).

- `calc_tsne.fallback_grid` stands in for `generate_tsne` + `calc_tsne_grid` and returns the same `(n, 2)` shape, so image rendering, tiles, `set_id` rotation and the config JSONs are untouched.
- `calc_tsne.single_cluster` presets `info['clusters']`; `cluster_screenshots` skips `find_clusters` when it is already set, so no LLM titling runs for the handful.
- Threshold is now `TSNEParams.MIN_TSNE_RECORDS` (default 10, as before). Zero usable records still writes nothing.
- Embeddings and the `ai_favorable_future` / `ai_plausibility` backfill already ran inside `load_records` before any count check; a comment and two tests now pin that.
- `CLAUDE.md` updated accordingly.

## Tests

14 new tests in `functions/tests/test_cluster_screenshots.py`: block layout, single cluster, the fallback end to end on a tiny grid (asserting t-SNE and lapjv are never called), the unchanged-hash skip, the t-SNE path for ≥10 records, and the analysis-regardless-of-count invariant. Full suite: 313 passed.

## Notes for review

- The Dutch/Hebrew/Arabic renderings of "future screenshots" in `FALLBACK_CLUSTER_TITLE` are my own; swap in the project's established names if there are any.
- The block is roughly square in cell count, so with tall screenshot cells it reads slightly taller than wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014sp5pVqwwyu3ivwpTqhT9R
