### PR TITLE
Make Dropbox ingest retries idempotent, and give the screenshot handler room

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,11 @@ open it can read that file. `parse_credentials` is the parser to match when gene
 Runs hold a Firestore lease (`dropbox_ingest/lock.py`), so overlapping invocations are safe
 — a second one logs `action: skipped` and exits.
 
+Provenance (`source`, `source_ref`, `author_id`, …) travels in the screenshot handler's
+`bookkeeping` form field and is stored **as the item is created**. That is what lets a retry
+find the item a killed handler created (it answered 503 after writing it) instead of making a
+second one — so do not move that data back to a follow-up `PUT`.
+
 ## Conventions
 
 - Errors that abort a per-item or per-workspace loop should be contained so one bad record

--- a/docs/API.md
+++ b/docs/API.md
@@ -680,7 +680,10 @@ POST /screenshot_handler?workspace=<id>&api_key=<key>&automatic=<bool>
 - `api_key` (required): Workspace admin or collaborate key
 - `automatic` (optional): Use automatic mode (true/false)
 
-**Request Body**: Image file
+**Form Fields**:
+- `image` (required): The image file
+- `metadata` (optional): JSON object of user-provided values. These are shown to the vision model as ground truth and override the corresponding analysed values.
+- `bookkeeping` (optional): JSON object stored on the item verbatim, in the same request that creates it. Never shown to the model. Use it for provenance fields (`source`, `source_ref`, `author_id`, …) that a caller needs on the item even if it never sees the response — the item can then be found with `GET /<workspace>/items?filters=metadata.source_ref=="…"`.
 
 **Description**: Analyzes screenshot using GPT-5.4 Vision model to extract structured information including screenshot type, content, future scenario details, and more. Always creates a new item. After creation, automatically generates the item's semantic embedding and assigns taxonomy topics (if a taxonomy exists). To update an existing item's image or re-analyze it, use the `replace_image` or `reanalyze_item` endpoints instead.
 
@@ -1070,11 +1073,12 @@ rotate_landscape: off       # off | cw | ccw — rescue landscape scans by rotat
 - Dedup is keyed on Dropbox's own `content_hash`, so a re-uploaded or moved copy of the same bytes is
   recognised without downloading it. Two copies of the same bytes in one folder (a Dropbox
   "conflicted copy") upload once.
-- A `files` entry with a `metadata_error` means the item was created but its `author_id` could not be
-  attached. It is deliberately not retried — retrying would create a second item — so fix it by
-  PUTting the metadata onto the recorded `item_id`.
 - `failed` entries are retried on later runs and quarantined after 3 attempts; a quarantined file is
   reported (`action: quarantined`) on every subsequent run. Delete the entry to force a retry.
+- Before a retry re-posts a file, the workspace is searched for an item whose `source_ref` is that
+  file's content hash: a handler that was killed after creating the item answers with a 503, and
+  without the lookup the retry would create a second item. A `files` entry with `recovered: true`
+  was adopted this way. If the lookup itself fails the file is uploaded anyway.
 - Deleting the whole file causes the folder to be ingested again from scratch.
 
 ### Batching and `author_id`
@@ -1102,15 +1106,13 @@ Per image, identical to the app's automatic mode:
 POST {SCREENSHOT_HANDLER_URL}?workspace=<id>&api_key=<key>&automatic=true
 Content-Type: multipart/form-data     (field: image)
 
-PUT {CHRONOMAPS_API_URL}/<workspace>/<item_id>?item-key=<item_key>
-Authorization: <api_key>
-
-{"author_id": "<batch uuid4>", "source": "dropbox", "dropbox_path": "...",
- "dropbox_content_hash": "...", "scanned_at": "..."}
+bookkeeping={"author_id": "<batch uuid4>", "source": "dropbox", "source_ref": "<content hash>",
+             "dropbox_path": "...", "dropbox_content_hash": "...", "scanned_at": "..."}
 ```
 
-Bookkeeping metadata goes in the `PUT`, never in the handler's `metadata` form field — that field is
-fed to the vision model as user-provided truth.
+Bookkeeping metadata goes in the handler's `bookkeeping` form field, which is written onto the item
+as it is created — never in the `metadata` form field, which is fed to the vision model as
+user-provided truth. Creating and labelling in one request is what makes a retry safe (see above).
 
 ### Triggers
 

--- a/docs/DROPBOX_SETUP.md
+++ b/docs/DROPBOX_SETUP.md
@@ -152,7 +152,7 @@ Once the function is deployed, `dropbox_ingest_scheduled` does this every minute
 | Every image errors with 403 | Collaboration disabled on the workspace, or a stale key in `chronomaps.config` |
 | Folder is listed as "before the cutoff" | It already contained scans older than `DROPBOX_FOLDER_CUTOFF`; add `ignore_cutoff: true` |
 | `action: quarantined` in the output | A file failed 3 times and is no longer retried; fix the cause, then delete its entry from `chronomaps.state.json` |
-| An image was uploaded twice | Should not happen — check whether `chronomaps.state.json` was deleted or the folder was copied |
+| An image was uploaded twice | Check whether `chronomaps.state.json` was deleted or the folder was copied. If the first copy has no `source`/`dropbox_path` metadata, the handler was killed mid-request (look for `screenshot_handler returned 503` in the ingest log and memory errors in the handler's); the retry should have adopted that item — see `recovered` in the state file |
 | Nothing at all is ingested | No credentials file in any folder; `scripts/dropbox_check.py` says which folders are skipped and why |
 
 ## Rotating or revoking access

--- a/functions/dropbox_ingest/__init__.py
+++ b/functions/dropbox_ingest/__init__.py
@@ -10,9 +10,12 @@ Flow, per run:
    syncing are grouped into scan batches by time gap; every image in a batch
    gets the same `author_id`.
 4. Each image is centre-cropped to the 0.53:1 page ratio (or rejected), then
-   uploaded through the same endpoints the screenshots app uses in auto mode:
-   POST screenshot_handler?automatic=true, then PUT the bookkeeping metadata.
+   uploaded through the same endpoint the screenshots app uses in auto mode:
+   POST screenshot_handler?automatic=true, with the bookkeeping metadata in a
+   form field the handler stores on the item as it creates it.
 5. The state file in the Dropbox folder is updated so nothing is uploaded twice.
+   A file whose upload failed is retried on a later run; before re-posting, the
+   workspace is searched for an item that the failed attempt created anyway.
 
 Everything is driven by injected settings/client objects so the flow can run
 from the scheduled Cloud Function, the HTTP trigger or the local CLI.
@@ -283,6 +286,12 @@ def merge_states(remote, local):
         combined = dict(remote.get(key) or {})
         combined.update(local.get(key) or {})
         merged[key] = combined
+    # A file that either side has settled is no longer failed, whatever the
+    # other side's copy says — otherwise a retry that succeeded would come back
+    # from the merge still carrying its failure.
+    for key in list(merged['failed']):
+        if key in merged['files'] or key in merged['skipped']:
+            del merged['failed'][key]
     merged['version'] = STATE_VERSION
     merged['workspace'] = local.get('workspace') or remote.get('workspace')
     merged.pop('last_batch', None)
@@ -480,15 +489,20 @@ def _now():
 def upload_scan(settings, config, image_bytes, filename, author_id, metadata, session=None):
     """Upload one prepared image, the same way the app does in auto mode.
 
-    POST to the screenshot handler with `automatic=true` (which analyses the
-    image and creates the item), then PUT the bookkeeping metadata onto the new
-    item — deliberately not via the handler's `metadata` form field, which is
-    fed to the vision prompt as user-provided truth.
+    POST to the screenshot handler with `automatic=true`, which analyses the
+    image and creates the item. The bookkeeping metadata (author, source path,
+    `source_ref`) goes in the `bookkeeping` form field, which the handler writes
+    onto the item in the same request that creates it — deliberately not the
+    `metadata` form field, which is fed to the vision prompt as user-provided
+    truth. Labelling the item as it is created means that when the handler dies
+    after creating it (the response is a 503), the item is still findable by
+    `source_ref` rather than being a nameless duplicate.
     """
     http = session or requests
     response = http.post(
         settings.screenshot_handler_url,
         files={'image': (filename, BytesIO(image_bytes), 'image/jpeg')},
+        data={'bookkeeping': json.dumps(dict(metadata, author_id=author_id))},
         params={'workspace': config.workspace, 'api_key': config.api_key, 'automatic': 'true'},
         timeout=UPLOAD_TIMEOUT,
     )
@@ -499,21 +513,27 @@ def upload_scan(settings, config, image_bytes, filename, author_id, metadata, se
     item_key = payload.get('item_key') or (payload.get('metadata') or {}).get('item_key')
     if not item_id:
         raise RuntimeError(f'screenshot_handler returned no item_id: {str(payload)[:500]}')
+    return item_id, item_key
 
-    # Mirrors screenshot_handler.update_item, without pulling in its Firebase deps.
-    update = http.put(
-        f'{settings.chronomaps_api_url}/{config.workspace}/{item_id}',
-        json=dict(metadata, author_id=author_id),
+
+def find_existing_item(settings, config, source_ref, session=None):
+    """The item an earlier attempt created for this scan, or None.
+
+    A handler that is killed after creating the item answers with a 503, which
+    is indistinguishable from "nothing was created". Since the bookkeeping is
+    written at creation, the workspace can be asked instead of guessing.
+    """
+    http = session or requests
+    response = http.get(
+        f'{settings.chronomaps_api_url}/{config.workspace}/items',
+        params={'filters': f'metadata.source_ref=={json.dumps(source_ref)}', 'page_size': 1},
         headers={'Authorization': config.api_key},
-        params={'item-key': item_key} if item_key else None,
         timeout=UPLOAD_TIMEOUT,
     )
-    # The item already exists at this point, so a failed PUT is reported rather
-    # than raised: retrying the upload would create a duplicate item.
-    metadata_error = None
-    if update.status_code >= 400:
-        metadata_error = f'metadata update returned {update.status_code}: {update.text[:500]}'
-    return item_id, item_key, metadata_error
+    if response.status_code != 200:
+        raise RuntimeError(f'item lookup returned {response.status_code}: {response.text[:500]}')
+    items = response.json()
+    return items[0] if items else None
 
 
 # -- per-folder flow --------------------------------------------------------
@@ -607,12 +627,16 @@ def process_folder(client, folder, settings, dry_run=False, now=None, session=No
                        scanned_at=_iso(stamp), author_id=author_id)
         return
 
+    # Files with a failed attempt behind them: the attempt may have created an
+    # item without getting to say so.
+    retrying = {entry_key(e) for e, _stamp, _author in capped if entry_key(e) in state['failed']}
+
     processed = 0
     for chunk in _chunks(capped, STATE_FLUSH_EVERY):
         if deadline is not None and time.monotonic() > deadline:
             yield dict(folder=name, action='deadline', deferred=len(capped) - processed)
             break
-        results = _process_chunk(client, chunk, config, settings, session, name)
+        results = _process_chunk(client, chunk, config, settings, session, name, retrying=retrying)
         for result in results:
             _record(state, result, now)
             processed += 1
@@ -625,12 +649,30 @@ def process_folder(client, folder, settings, dry_run=False, now=None, session=No
     yield dict(folder=name, action='folder-done', uploaded=processed)
 
 
-def _process_chunk(client, chunk, config, settings, session, folder_name):
-    """Download, crop and upload a chunk of scans concurrently."""
+def _process_chunk(client, chunk, config, settings, session, folder_name, retrying=frozenset()):
+    """Download, crop and upload a chunk of scans concurrently.
+
+    `retrying` holds the keys of scans a previous run failed on; those are
+    looked up in the workspace first, in case the failed attempt created the
+    item after all.
+    """
     def handle(assignment):
         entry, stamp, author_id = assignment
+        source_ref = entry_key(entry)
         base = dict(folder=folder_name, workspace=config.workspace, path=entry.get('path_display'),
-                    content_hash=entry_key(entry), scanned_at=_iso(stamp), author_id=author_id)
+                    content_hash=source_ref, scanned_at=_iso(stamp), author_id=author_id)
+        if source_ref in retrying:
+            try:
+                existing = find_existing_item(settings, config, source_ref, session)
+            except Exception as e:                              # noqa: BLE001 - best effort; uploading is the fallback
+                existing = None
+                base['lookup_error'] = f'{type(e).__name__}: {e}'
+            if existing:
+                # The earlier attempt did create it; adopt that item rather than
+                # make a second one. Its author is whoever it was filed under.
+                return dict(base, action='uploaded', recovered=True,
+                            item_id=existing.get('_id'), item_key=existing.get('_key'),
+                            author_id=existing.get('author_id') or author_id)
         try:
             data = client.download(entry['path_display'])
             expected = entry.get('size')
@@ -647,18 +689,16 @@ def _process_chunk(client, chunk, config, settings, session, folder_name):
             return dict(base, action='error', error=f'{type(e).__name__}: {e}')
 
         try:
-            item_id, item_key, metadata_error = upload_scan(
+            item_id, item_key = upload_scan(
                 settings, config, image_bytes, entry['name'], author_id,
-                metadata=dict(source='dropbox', dropbox_path=entry.get('path_display'),
+                metadata=dict(source='dropbox', source_ref=source_ref,
+                              dropbox_path=entry.get('path_display'),
                               dropbox_content_hash=entry.get('content_hash'),
                               scanned_at=_iso(stamp)),
                 session=session)
         except Exception as e:                                  # noqa: BLE001 - reported, retried next run
             return dict(base, action='error', error=f'{type(e).__name__}: {e}')
-        result = dict(base, action='uploaded', item_id=item_id, item_key=item_key, **info)
-        if metadata_error:
-            result['metadata_error'] = metadata_error
-        return result
+        return dict(base, action='uploaded', item_id=item_id, item_key=item_key, **info)
 
     with ThreadPoolExecutor(max_workers=UPLOAD_WORKERS) as pool:
         return list(pool.map(handle, chunk))
@@ -671,13 +711,11 @@ def _record(state, result, now):
         return
     stamp = _iso(now)
     if result['action'] == 'uploaded':
-        # Recorded even when the metadata PUT failed: the item exists, so a
-        # retry would duplicate it rather than repair it.
         record = dict(path=result.get('path'), item_id=result.get('item_id'),
                       author_id=result.get('author_id'),
                       scanned_at=result.get('scanned_at'), uploaded_at=stamp)
-        if result.get('metadata_error'):
-            record['metadata_error'] = result['metadata_error']
+        if result.get('recovered'):
+            record['recovered'] = True
         state['files'][content_hash] = record
         state['failed'].pop(content_hash, None)
     elif result['action'] == 'skip-image':

--- a/functions/functions.yaml
+++ b/functions/functions.yaml
@@ -115,8 +115,8 @@ endpoints:
     serviceAccountEmail: null
     timeoutSeconds: 60
   screenshot_handler:
-    availableMemoryMb: 512
-    concurrency: null
+    availableMemoryMb: 1024
+    concurrency: 4
     entryPoint: screenshot_handler
     httpsTrigger: {}
     ingressSettings: null

--- a/functions/main.py
+++ b/functions/main.py
@@ -46,7 +46,12 @@ def chronomaps_api(req: https_fn.Request) -> https_fn.Response:
     with chronomaps_api_app.request_context(environ):
         return chronomaps_api_app.full_dispatch_request()
     
-@https_fn.on_request(region='europe-west4', cors=options.CorsOptions(cors_origins="*", cors_methods=["post"]), secrets=['OPENAI_API_KEY', 'CHRONOMAPS_API_URL'], memory=options.MemoryOption.MB_512)
+# The Dropbox ingest posts four scans at a time. Four concurrent analyses on one
+# 512 MB instance ran it to 570-580 MiB (2026-09-08) and Cloud Run killed it
+# mid-request, after the item was created but before the client heard so: the
+# caller got a 503 and re-uploaded. Memory for the analyses; a concurrency cap
+# so a burst cannot stack more of them on one instance than that memory holds.
+@https_fn.on_request(region='europe-west4', cors=options.CorsOptions(cors_origins="*", cors_methods=["post"]), secrets=['OPENAI_API_KEY', 'CHRONOMAPS_API_URL'], memory=options.MemoryOption.GB_1, concurrency=4)
 def screenshot_handler(req: https_fn.Request) -> https_fn.Response:
     # Get the request data
     # Workspace and api_key from query parameters:
@@ -66,8 +71,11 @@ def screenshot_handler(req: https_fn.Request) -> https_fn.Response:
     # Read optional user-provided metadata from form fields
     user_metadata_raw = req.form.get('metadata')
     user_metadata = json.loads(user_metadata_raw) if user_metadata_raw else None
+    # Bookkeeping is stored on the item as-is and never shown to the model.
+    bookkeeping_raw = req.form.get('bookkeeping')
+    bookkeeping = json.loads(bookkeeping_raw) if bookkeeping_raw else None
 
-    return screenshot_handler_fn(image_bytes=image_bytes, workspace=workspace, api_key=api_key, automatic=automatic, image_content_type=content_type, user_metadata=user_metadata)
+    return screenshot_handler_fn(image_bytes=image_bytes, workspace=workspace, api_key=api_key, automatic=automatic, image_content_type=content_type, user_metadata=user_metadata, bookkeeping=bookkeeping)
 
 @https_fn.on_request(region='europe-west4', cors=options.CorsOptions(cors_origins="*", cors_methods=["post"]), secrets=['CHRONOMAPS_API_URL'], memory=options.MemoryOption.MB_512)
 def replace_image(req: https_fn.Request) -> https_fn.Response:

--- a/functions/screenshot_handler/__init__.py
+++ b/functions/screenshot_handler/__init__.py
@@ -234,14 +234,21 @@ def download_item_image(workspace, item_id):
     return image_bytes, content_type
 
 
-def screenshot_handler(image_bytes, workspace, api_key, automatic=False, image_content_type='image/jpeg', user_metadata=None):
-    """Full flow: analyze image, create new item, upload image."""
+def screenshot_handler(image_bytes, workspace, api_key, automatic=False, image_content_type='image/jpeg', user_metadata=None, bookkeeping=None):
+    """Full flow: analyze image, create new item, upload image.
+
+    `user_metadata` is shown to the model as user-provided truth; `bookkeeping`
+    is not — it is written onto the item verbatim, in the same request that
+    creates it, so a caller whose response is lost can still find its item.
+    """
     record = analyze_image(image_bytes, image_content_type, automatic=automatic, user_metadata=user_metadata)
 
     # Override AI-generated values with user-provided ones so they are preserved
     if user_metadata:
         record['_original_ai_analysis'] = {k: v for k, v in record.items() if k in user_metadata}
         record.update(user_metadata)
+    if bookkeeping:
+        record.update(bookkeeping)
 
     moderation_result = get_workspace_moderation(workspace, api_key)
     if isinstance(moderation_result[0], dict) and 'error' in moderation_result[0]:

--- a/functions/tests/test_dropbox_ingest.py
+++ b/functions/tests/test_dropbox_ingest.py
@@ -18,7 +18,7 @@ from dropbox_ingest import (
     ConfigurationError, FolderConfig, Settings, assign_batches, batches_from, group_entries,
     derive_handler_url, empty_state, entry_key, find_config_entry, folder_created_at,
     is_known, merge_batches, merge_states, parse_credentials, process_folder, read_state,
-    run_ingest, scan_time, upload_scan, write_state, MAX_FILE_ATTEMPTS,
+    run_ingest, scan_time, upload_scan, find_existing_item, write_state, MAX_FILE_ATTEMPTS,
     DEFAULT_BATCH_GAP_SECONDS, DEFAULT_MAX_UPLOADS_PER_RUN,
 )
 from dropbox_ingest.dropbox_api import (
@@ -458,6 +458,14 @@ class TestState:
 
 
 # -- image preparation ------------------------------------------------------
+    def test_merge_drops_failures_that_either_side_has_settled(self):
+        remote = dict(empty_state('ws'), failed={'h1': {'attempts': 1}, 'h2': {'attempts': 1}})
+        local = dict(empty_state('ws'), files={'h1': {'item_id': 'i1'}}, skipped={'h2': {'reason': 'r'}},
+                     failed={'h3': {'attempts': 2}})
+        merged = merge_states(remote, local)
+        assert merged['failed'] == {'h3': {'attempts': 2}}
+        assert set(merged['files']) == {'h1'} and set(merged['skipped']) == {'h2'}
+
 
 class TestPrepareImage:
     def test_exact_ratio_passes_through(self):
@@ -521,39 +529,36 @@ class TestPrepareImage:
 # -- upload -----------------------------------------------------------------
 
 class TestUploadScan:
-    def _session(self, post_payload=None, post_status=200, put_status=200):
+    def _session(self, post_payload=None, post_status=200):
         session = Mock()
         post_response = Mock(status_code=post_status, text='')
         post_response.json.return_value = post_payload or {'item_id': 'item-1', 'item_key': 'key-1'}
         session.post.return_value = post_response
-        session.put.return_value = Mock(status_code=put_status, text='')
         return session
 
-    def test_posts_in_automatic_mode_and_puts_author_id(self):
+    def test_posts_in_automatic_mode_with_bookkeeping(self):
         session = self._session()
         config = FolderConfig(workspace='ws-1', api_key='api-key')
-        item_id, item_key, metadata_error = upload_scan(
+        item_id, item_key = upload_scan(
             make_settings(), config, b'jpeg', 'page.jpg', 'author-9',
-            {'source': 'dropbox'}, session=session)
+            {'source': 'dropbox', 'source_ref': 'hash-1'}, session=session)
 
-        assert (item_id, item_key, metadata_error) == ('item-1', 'key-1', None)
-        post_params = session.post.call_args.kwargs['params']
-        assert post_params == {'workspace': 'ws-1', 'api_key': 'api-key', 'automatic': 'true'}
-        assert 'image' in session.post.call_args.kwargs['files']
+        assert (item_id, item_key) == ('item-1', 'key-1')
+        post_kwargs = session.post.call_args.kwargs
+        assert post_kwargs['params'] == {'workspace': 'ws-1', 'api_key': 'api-key', 'automatic': 'true'}
+        assert 'image' in post_kwargs['files']
+        bookkeeping = json.loads(post_kwargs['data']['bookkeeping'])
+        assert bookkeeping == {'source': 'dropbox', 'source_ref': 'hash-1', 'author_id': 'author-9'}
+        # Everything the item needs travels with the creating request: a lost
+        # response must not leave an unlabelled item behind.
+        assert not session.put.called
 
-        put_args = session.put.call_args
-        assert put_args.args[0] == 'https://api.example.com/ws-1/item-1'
-        assert put_args.kwargs['json']['author_id'] == 'author-9'
-        assert put_args.kwargs['json']['source'] == 'dropbox'
-        assert put_args.kwargs['headers'] == {'Authorization': 'api-key'}
-        assert put_args.kwargs['params'] == {'item-key': 'key-1'}
-
-    def test_metadata_is_not_sent_to_the_vision_prompt(self):
+    def test_bookkeeping_is_not_sent_to_the_vision_prompt(self):
         """Bookkeeping fields must not ride along in the handler's `metadata` form field."""
         session = self._session()
         upload_scan(make_settings(), FolderConfig(workspace='ws', api_key='k'), b'jpeg', 'p.jpg',
                     'author', {'source': 'dropbox'}, session=session)
-        assert 'data' not in session.post.call_args.kwargs
+        assert set(session.post.call_args.kwargs['data']) == {'bookkeeping'}
         assert set(session.post.call_args.kwargs['files']) == {'image'}
 
     def test_handler_failure_raises(self):
@@ -562,14 +567,34 @@ class TestUploadScan:
             upload_scan(make_settings(), FolderConfig(workspace='ws', api_key='k'), b'x', 'p.jpg',
                         'a', {}, session=session)
 
-    def test_metadata_failure_is_reported_not_raised(self):
-        """The item already exists — raising would make the next run duplicate it."""
-        session = self._session(put_status=500)
-        item_id, _key, metadata_error = upload_scan(
-            make_settings(), FolderConfig(workspace='ws', api_key='k'), b'x', 'p.jpg',
-            'a', {}, session=session)
-        assert item_id == 'item-1'
-        assert 'metadata update returned 500' in metadata_error
+
+class TestFindExistingItem:
+    def test_queries_the_workspace_by_source_ref(self):
+        session = Mock()
+        session.get.return_value = Mock(status_code=200)
+        session.get.return_value.json.return_value = [{'_id': 'item-7', 'author_id': 'a'}]
+        found = find_existing_item(make_settings(), FolderConfig(workspace='ws-1', api_key='k'),
+                                   'hash-1', session=session)
+        assert found == {'_id': 'item-7', 'author_id': 'a'}
+        get = session.get.call_args
+        assert get.args[0] == 'https://api.example.com/ws-1/items'
+        # Quoted, so a hash that happens to be all digits is not parsed as a number.
+        assert get.kwargs['params']['filters'] == 'metadata.source_ref=="hash-1"'
+        assert get.kwargs['headers'] == {'Authorization': 'k'}
+
+    def test_none_when_nothing_matches(self):
+        session = Mock()
+        session.get.return_value = Mock(status_code=200)
+        session.get.return_value.json.return_value = []
+        assert find_existing_item(make_settings(), FolderConfig(workspace='ws', api_key='k'),
+                                  'hash-1', session=session) is None
+
+    def test_api_failure_raises(self):
+        session = Mock()
+        session.get.return_value = Mock(status_code=500, text='boom')
+        with pytest.raises(RuntimeError):
+            find_existing_item(make_settings(), FolderConfig(workspace='ws', api_key='k'),
+                               'hash-1', session=session)
 
 
 # -- folder flow ------------------------------------------------------------
@@ -630,7 +655,8 @@ def upload_session():
         return response
 
     session.post.side_effect = post
-    session.put.return_value = Mock(status_code=200, text='')
+    session.get.return_value = Mock(status_code=200)
+    session.get.return_value.json.return_value = []
     return session
 
 
@@ -747,31 +773,61 @@ class TestProcessFolder:
 class TestPartialFailures:
     """Cases where an image could be uploaded twice, or lost entirely."""
 
-    def test_failed_metadata_put_does_not_re_upload_next_run(self):
-        session = Mock()
-        post_response = Mock(status_code=200, text='')
-        post_response.json.return_value = {'item_id': 'item-a', 'item_key': 'k'}
-        session.post.return_value = post_response
-        session.put.return_value = Mock(status_code=500, text='nope')
+    FILE = ('a.jpg', image_bytes(530, 1000), '2026-08-25T10:00:00Z', '2026-08-25T10:00:20Z')
 
-        fixture = FolderFixture(files=[
-            ('a.jpg', image_bytes(530, 1000), '2026-08-25T10:00:00Z', '2026-08-25T10:00:20Z'),
-        ])
+    def _failed_once(self):
+        """The state after a run whose upload of a.jpg got a 503."""
+        return dict(empty_state('ws-1'), failed={'hash-a.jpg': {
+            'path': '/archive/ws/a.jpg', 'attempts': 1, 'at': '2026-08-25T10:05:00Z',
+            'error': 'RuntimeError: screenshot_handler returned 503: Service Unavailable'}})
+
+    def test_retry_adopts_the_item_the_failed_attempt_created(self):
+        """A handler killed after creating the item answers 503; the item is still there."""
+        session = upload_session()
+        session.get.return_value.json.return_value = [
+            {'_id': 'item-from-before', 'author_id': 'author-from-before', 'source_ref': 'hash-a.jpg'}]
+        fixture = FolderFixture(files=[self.FILE], state=self._failed_once())
         results = fixture.run(session=session)
 
         uploaded = [r for r in results if r['action'] == 'uploaded']
-        assert len(uploaded) == 1 and 'metadata update returned 500' in uploaded[0]['metadata_error']
-        record = fixture.state()['files']['hash-a.jpg']
-        assert record['item_id'] == 'item-a'
-        assert 'metadata_error' in record, 'visible to a human, but never retried'
+        assert len(uploaded) == 1 and uploaded[0]['recovered'] is True
+        assert uploaded[0]['item_id'] == 'item-from-before'
+        assert uploaded[0]['author_id'] == 'author-from-before', 'filed under its original batch'
+        assert session.post.call_count == 0, 'no second item'
+        assert session.get.call_args.kwargs['params']['filters'] == 'metadata.source_ref=="hash-a.jpg"'
 
-        # Second run over the same folder: the item exists, so nothing is re-posted.
-        second = FolderFixture(
-            files=[('a.jpg', image_bytes(530, 1000), '2026-08-25T10:00:00Z', '2026-08-25T10:00:20Z')],
-            state=fixture.state())
-        session.post.reset_mock()
-        second.run(session=session)
-        assert session.post.call_count == 0
+        state = fixture.state()
+        assert state['files']['hash-a.jpg']['item_id'] == 'item-from-before'
+        assert state['files']['hash-a.jpg']['recovered'] is True
+        assert 'hash-a.jpg' not in state['failed']
+
+    def test_retry_uploads_when_no_item_was_created(self):
+        session = upload_session()
+        fixture = FolderFixture(files=[self.FILE], state=self._failed_once())
+        results = fixture.run(session=session)
+
+        uploaded = [r for r in results if r['action'] == 'uploaded']
+        assert len(uploaded) == 1 and 'recovered' not in uploaded[0]
+        assert session.get.call_count == 1 and session.post.call_count == 1
+        assert fixture.state()['files']['hash-a.jpg']['item_id'] == 'item-a'
+
+    def test_retry_uploads_when_the_lookup_itself_fails(self):
+        """The lookup is a safeguard, not a gate: the API being down must not stall the file."""
+        session = upload_session()
+        session.get.return_value = Mock(status_code=500, text='down')
+        fixture = FolderFixture(files=[self.FILE], state=self._failed_once())
+        results = fixture.run(session=session)
+
+        uploaded = [r for r in results if r['action'] == 'uploaded']
+        assert len(uploaded) == 1 and 'item lookup returned 500' in uploaded[0]['lookup_error']
+        assert session.post.call_count == 1
+
+    def test_first_attempt_does_not_look_up(self):
+        """Only a file with a failed attempt behind it can have a hidden item."""
+        session = upload_session()
+        fixture = FolderFixture(files=[self.FILE])
+        fixture.run(session=session)
+        assert session.get.call_count == 0 and session.post.call_count == 1
 
     def test_duplicate_content_in_one_listing_uploads_once(self):
         """Conflicted copies share a content hash — and the state file has one record per hash."""

--- a/functions/tests/test_screenshot_handler.py
+++ b/functions/tests/test_screenshot_handler.py
@@ -307,6 +307,27 @@ class TestScreenshotHandler:
         call_kwargs = mock_enhance_image.call_args[1]
         assert "screenshot_url" in call_kwargs
 
+    def test_bookkeeping_is_stored_at_creation_and_hidden_from_the_model(
+            self, mock_openai, mock_api_requests, mock_storage):
+        """A caller whose response is lost must still find its item by these fields."""
+        from screenshot_handler import screenshot_handler
+
+        screenshot_handler(
+            image_bytes=SAMPLE_IMAGE,
+            workspace="ws",
+            api_key="key",
+            image_content_type="image/jpeg",
+            bookkeeping={"source": "dropbox", "source_ref": "hash-1", "author_id": "batch-1"},
+        )
+
+        created = mock_api_requests.post.call_args.kwargs["json"]
+        assert created["source"] == "dropbox"
+        assert created["source_ref"] == "hash-1"
+        assert created["author_id"] == "batch-1"
+        assert created["screenshot_type"] == "social_media_post", "analysis is kept alongside"
+        prompt = json.dumps(mock_openai.chat.completions.create.call_args.kwargs, default=str)
+        assert "hash-1" not in prompt and "batch-1" not in prompt
+
     def test_returns_error_if_workspace_not_found(self, mock_openai, mock_api_requests, mock_storage):
         from screenshot_handler import screenshot_handler
 


### PR DESCRIPTION
## Why

`IMG_2026_09_08_13_18_28_3` from `26-09-09-ars-electronica` was ingested twice on 2026-09-08. From the logs:

1. The ingester posted the four pages of a scan batch concurrently to the screenshot handler.
2. The handler (512 MB, default concurrency 80) took all four on one instance, hit 571 MiB and was killed by Cloud Run **after** creating the item and uploading the screenshot, but before replying. The ingester got a `503`.
3. The ingester recorded a failure and, on the next run, uploaded the page again. Result: a real item plus an unlabelled orphan (no `source` / `dropbox_path` / `author_id`).

The handler logged memory overruns on the next two chunks as well; those just happened to finish first.

## What

**Headroom.** `screenshot_handler` goes to 1 GB with a concurrency cap of 4, in both the decorator and `functions.yaml` (the manifest wins, so both). Deployed service is on 1 CPU, so the cap is valid.

**Idempotent retries.** The collaborate key cannot read item keys back from `GET /items`, so a retry that *found* an existing item could not have PUT the author onto it. Instead the provenance now travels with the creating request:

- The handler accepts a `bookkeeping` form field, written onto the item in the same request that creates it and never shown to the model (unlike `metadata`).
- The ingester sends all provenance there, including `source_ref` = the Dropbox content hash, and drops the follow-up PUT. A lost response now leaves a fully labelled item.
- Before re-posting a file with a failed attempt behind it, the ingester queries the workspace by `source_ref` and adopts the existing item if there is one, keeping its original author (`recovered: true` in the state file). A failed lookup falls back to uploading. A first attempt never looks up, so normal runs cost nothing extra.

**Merge fix.** Writing the tests surfaced that `merge_states` (used on a state-file write conflict) resurrected a `failed` entry the run had just resolved. It now drops any failure that either side has settled.

The orphan item has already been deleted from Firestore and the bucket by hand.

## Notes for review

- The retry lookup uses `filters=metadata.source_ref=="…"` alongside the API's moderation filter. The first such query per workspace will fall back to in-memory filtering and trigger index creation in the background, which is the API's normal behaviour for a new filter shape.
- Docs updated: `docs/API.md` (handler form fields, ingest state file, upload path), `docs/DROPBOX_SETUP.md` (troubleshooting), `CLAUDE.md` (why bookkeeping must stay on the creating request).

## Tests

`cd functions && pytest tests/` — 320 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vph84FLaqTavzddJDJ8c39
