### PR TITLE
Scale t-SNE perplexity with the record count, and cluster every 5 minutes

### DIFF
--- a/functions/cluster_screenshots/calc_tsne.py
+++ b/functions/cluster_screenshots/calc_tsne.py
@@ -440,8 +440,9 @@ def cluster_screenshots_inner(config, params: TSNEParams, last_state_hash=None):
         grid = fallback_grid(len(records), params.OUT_DIM)
     else:
         activations = [rec['embedding'] for rec in records]
-        yield dict(msg=f'Generating 2D representation from {len(records)} records.')
-        X_2d = generate_tsne(activations, perplexity=min(params.PERPLEXITY, len(records)-1), tsne_iter=params.TSNE_ITER)
+        perplexity = params.perplexity_for(len(records))
+        yield dict(msg=f'Generating 2D representation from {len(records)} records (perplexity {perplexity}).')
+        X_2d = generate_tsne(activations, perplexity=perplexity, tsne_iter=params.TSNE_ITER)
         yield dict(msg="Generating image grid (%dx%d, %d images" % (params.OUT_DIM[0], params.OUT_DIM[1], len(records)))
         grid = calc_tsne_grid(X_2d, params.OUT_DIM)
         grid = grid[:len(records)]

--- a/functions/cluster_screenshots/tsne_params.py
+++ b/functions/cluster_screenshots/tsne_params.py
@@ -5,7 +5,14 @@ from dataclasses import dataclass
 @dataclass
 class TSNEParams():
     EMBEDDING_DIMENSION: int = 3072
+    # Perplexity is roughly how many neighbours each point attends to. It is
+    # scaled with the record count (about a third of it, between MIN_PERPLEXITY
+    # and PERPLEXITY): a fixed 50 capped at n-1 meant that a small set had every
+    # point attending to every other, so t-SNE spread them out evenly and no
+    # clusters could form.
     PERPLEXITY: int = 50
+    MIN_PERPLEXITY: int = 5
+    PERPLEXITY_FRACTION: float = 1 / 3
     TSNE_ITER: int = 5000
     ORIGINAL_IMAGE_SIZE: int = (530, 1000)
     CELL_RATIOS: int = (1.86, 1.135)
@@ -33,6 +40,11 @@ class TSNEParams():
         self.OUT_DIM_Y = int(round(self.OUT_DIM_X * self.ORIGINAL_IMAGE_SIZE[0] * self.CELL_RATIOS[0] * self.OUT_RATIO / (self.ORIGINAL_IMAGE_SIZE[1] * self.CELL_RATIOS[1])))
         self.OUT_DIM = (self.OUT_DIM_X, self.OUT_DIM_Y)
         self.TO_PLOT = int(self.OUT_DIM_X * self.OUT_DIM_Y * self.FILL_RATIO)
+
+    def perplexity_for(self, num_records):
+        """Perplexity for a set of num_records, always below the count (t-SNE requires it)."""
+        scaled = int(num_records * self.PERPLEXITY_FRACTION)
+        return max(1, min(max(self.MIN_PERPLEXITY, scaled), self.PERPLEXITY, num_records - 1))
 
     def __str__(self):
         return f"TSNEParams(TAG={self.TAG}," +\

--- a/functions/functions.yaml
+++ b/functions/functions.yaml
@@ -73,7 +73,7 @@ endpoints:
     - europe-west1
     scheduleTrigger:
       retryConfig: {}
-      schedule: every 15 minutes
+      schedule: every 5 minutes
     secretEnvironmentVariables:
     - key: CHRONOMAPS_API_URL
     - key: OPENAI_API_KEY

--- a/functions/main.py
+++ b/functions/main.py
@@ -227,7 +227,7 @@ def enhance_all(req: https_fn.Request) -> https_fn.Response:
             yield f"data: {json.dumps([delta, bit], ensure_ascii=False)}\n\n"
     return https_fn.Response(generate(), status=200, mimetype='text/event-stream')
 
-@scheduler_fn.on_schedule(region='europe-west1', schedule="every 15 minutes", secrets=['CHRONOMAPS_API_URL', 'OPENAI_API_KEY', 'CONFIG__ITS_TIME'], memory=options.MemoryOption.GB_8)
+@scheduler_fn.on_schedule(region='europe-west1', schedule="every 5 minutes", secrets=['CHRONOMAPS_API_URL', 'OPENAI_API_KEY', 'CONFIG__ITS_TIME'], memory=options.MemoryOption.GB_8)
 def cluster_its_time(event: scheduler_fn.ScheduledEvent) -> None:
     config_tags_tuples = []
     print("STARTING clustering all workspaces")

--- a/functions/tests/test_cluster_screenshots.py
+++ b/functions/tests/test_cluster_screenshots.py
@@ -155,9 +155,34 @@ class TestClusterScreenshotsInnerFallback:
             actions = _run(records, params)
 
         tsne.assert_called_once()
+        assert tsne.call_args.kwargs['perplexity'] == params.perplexity_for(10)
         lap.assert_called_once()
         # Clustering and titling are left to find_clusters downstream.
         assert 'clusters' not in actions['clusters']['info']
+
+
+class TestPerplexity:
+    """Perplexity scales with the set: a fixed 50 capped at n-1 flattens small maps."""
+
+    @pytest.mark.parametrize('count, expected', [
+        (10, 5),     # floor: n/3 would be 3, which is too few neighbours to be meaningful
+        (11, 5),     # the case that prompted this: was 10 of 11, i.e. everyone is a neighbour
+        (15, 5),
+        (30, 10),
+        (90, 30),
+        (150, 50),   # ceiling
+        (500, 50),
+    ])
+    def test_scales_with_record_count(self, count, expected):
+        assert TSNEParams().perplexity_for(count) == expected
+
+    @pytest.mark.parametrize('count', [2, 3, 5, 6])
+    def test_always_below_the_record_count(self, count):
+        # t-SNE refuses perplexity >= n; the floor must give way to that.
+        assert 1 <= TSNEParams().perplexity_for(count) < count
+
+    def test_ceiling_is_configurable(self):
+        assert TSNEParams(PERPLEXITY=20).perplexity_for(500) == 20
 
 
 class TestAnalysisRunsRegardlessOfCount:


### PR DESCRIPTION
## Why

The `26-09-09-ars-electronica` map (11 records) came out as a sparse, even spread with no visible clustering. Perplexity was a fixed 50 capped at `n - 1`, so for 11 records it was 10: every point attended to every other point equally, and t-SNE had nothing to pull apart.

## What

`TSNEParams.perplexity_for(n)` returns about a third of the record count, clamped to `MIN_PERPLEXITY` (5) .. `PERPLEXITY` (50), and always below `n` as t-SNE requires. `cluster_screenshots_inner` uses it and logs the value it chose.

| records | before | after |
|---|---|---|
| 11 | 10 | 5 |
| 30 | 29 | 10 |
| 90 | 50 | 30 |
| 150+ | 50 | 50 |

This is deliberately the small change. The grid is still the fixed 23×20 and the output is still normalised to fill it, so an 11-record map will remain spread out; what changes is that neighbours now have room to land near each other. Sizing the grid to the record count (`origin/adaptive-tsne-grid`) is the larger fix and is left for a separate PR.

## Schedule

`cluster_its_time` now runs every 5 minutes instead of 15, in both the manifest and the decorator. Note the job has a 30-minute timeout and no lock, so a slow run can now overlap up to five later ones; each of those walks the same workspaces from the top. `if_changed` keeps the idle ones cheap, but a workspace that is mid-rebuild when the next run starts is built twice.

## Tests

`cd functions && pytest tests/` — 332 passed. New `TestPerplexity` covers the floor, ceiling, scaling, and the below-`n` guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vph84FLaqTavzddJDJ8c39