### PR TITLE
Page the clusterer's items fetch, and give clustering 16 GB

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,11 @@ Worth knowing before diagnosing a stalled map:
   order every run and always restarts from the beginning, so when runs die early the
   workspaces late in the alphabet are never reached. There is no cursor.
 - **No lock**, unlike the Dropbox ingest — overlapping runs both walk the same workspaces.
+- **Response size.** The items API answers in one Cloud Run response, capped at 32 MB. With
+  its embedding an item is ~63 KB, so `load_records` pages the fetch
+  (`TSNEParams.FETCH_PAGE_SIZE`). Before it did, any workspace past ~500 records came back
+  truncated and failed with `JSONDecodeError` on every run. The API still loads the whole
+  collection to serve each page, so a page costs ~20 s on a large workspace.
 
 To re-cluster one workspace without waiting for the batch, call the `cluster_screenshots`
 endpoint directly (see `run-jma25-tsne.sh`); it gets a whole invocation to itself.

--- a/functions/cluster_screenshots/calc_tsne.py
+++ b/functions/cluster_screenshots/calc_tsne.py
@@ -36,6 +36,35 @@ FALLBACK_CLUSTER_TITLE = dict(
     arabic='لقطات شاشة من المستقبل',
 )
 
+def fetch_items(workspace, api_key, req_params, wanted, params: TSNEParams):
+    """The workspace's first `wanted` items, fetched a page at a time.
+
+    One request for all of them exceeds Cloud Run's response size limit on a
+    large workspace (see TSNEParams.FETCH_PAGE_SIZE). Stops at a short page.
+    Returns the API's payload untouched when it is not a list (an error body),
+    so the caller can skip the workspace the way it always has.
+    """
+    items = []
+    seen = set()
+    page = 0
+    while len(items) < wanted:
+        page_params = dict(req_params, page=page, page_size=params.FETCH_PAGE_SIZE)
+        resp = requests.get(f'{params.CHRONOMAPS_API_URL}/{workspace}/items', page_params, headers={'Authorization': api_key})
+        resp.raise_for_status()
+        batch = resp.json()
+        if not isinstance(batch, list):
+            return batch if page == 0 else items
+        for item in batch:
+            item_id = item.get('_id')
+            if item_id is None or item_id not in seen:
+                seen.add(item_id)
+                items.append(item)
+        if len(batch) < params.FETCH_PAGE_SIZE:
+            break
+        page += 1
+    return items[:wanted]
+
+
 def load_records(config, records, params: TSNEParams):
     if len(config) > 1:
         max_per_workspace = int(params.TO_PLOT / 2)
@@ -45,14 +74,14 @@ def load_records(config, records, params: TSNEParams):
         if extra:
             min_range = int(extra[0])
             moderation_range = ','.join(str(i) for i in range(min_range, 6))
-            req_params = dict(page_size=params.TO_PLOT*2, order_by='-created_at', filters=f'metadata._private_moderation in [{moderation_range}]')
+            req_params = dict(order_by='-created_at', filters=f'metadata._private_moderation in [{moderation_range}]')
             yield dict(msg=f'Fetching from {workspace}... ({moderation_range})')
         else:
-            req_params = dict(page_size=params.TO_PLOT*2, order_by='-created_at')
+            req_params = dict(order_by='-created_at')
             yield dict(msg=f'Fetching from {workspace}...')
-        workspace_metadata = requests.get(f'{params.CHRONOMAPS_API_URL}/{workspace}', req_params, headers={'Authorization': api_key}).json()
+        workspace_metadata = requests.get(f'{params.CHRONOMAPS_API_URL}/{workspace}', headers={'Authorization': api_key}).json()
         req_params['include_embedding'] = 'true'
-        items = requests.get(f'{params.CHRONOMAPS_API_URL}/{workspace}/items', req_params, headers={'Authorization': api_key}).json()
+        items = fetch_items(workspace, api_key, req_params, wanted=params.TO_PLOT * 2, params=params)
         if isinstance(items, list):
             yield dict(msg=f'Got {len(items)} items.')
             yield from ensure_analysis(items, workspace, api_key, params)

--- a/functions/cluster_screenshots/tsne_params.py
+++ b/functions/cluster_screenshots/tsne_params.py
@@ -32,6 +32,11 @@ class TSNEParams():
     # Below this many records t-SNE is meaningless (and perplexity collapses),
     # so the map is drawn as one block in the middle instead of skipped.
     MIN_TSNE_RECORDS: int = 10
+    # Items are fetched from the API this many at a time. With its embedding an
+    # item is ~63 KB of JSON and Cloud Run drops responses over 32 MB, so asking
+    # for all TO_PLOT*2 (~690) items at once fails for any workspace past ~500
+    # records: the body comes back truncated and the JSON parse raises.
+    FETCH_PAGE_SIZE: int = 200
 
     OPENAI_KEY: str = None
     CHRONOMAPS_API_URL: str = None

--- a/functions/functions.yaml
+++ b/functions/functions.yaml
@@ -61,7 +61,7 @@ endpoints:
     serviceAccountEmail: null
     timeoutSeconds: null
   cluster_its_time:
-    availableMemoryMb: 8192
+    availableMemoryMb: 16384
     concurrency: null
     entryPoint: cluster_its_time
     ingressSettings: null
@@ -81,7 +81,7 @@ endpoints:
     serviceAccountEmail: null
     timeoutSeconds: 1800
   cluster_screenshots:
-    availableMemoryMb: 8192
+    availableMemoryMb: 16384
     concurrency: null
     entryPoint: cluster_screenshots
     httpsTrigger: {}

--- a/functions/main.py
+++ b/functions/main.py
@@ -163,7 +163,7 @@ def enhance_image(req: https_fn.Request) -> https_fn.Response:
         return json.dumps(result[0]), result[1]
     return json.dumps(result)
 
-@https_fn.on_request(region='europe-west4', cors=options.CorsOptions(cors_origins="*", cors_methods=["post"]), secrets=['CHRONOMAPS_API_URL', 'OPENAI_API_KEY'], memory=options.MemoryOption.GB_8)
+@https_fn.on_request(region='europe-west4', cors=options.CorsOptions(cors_origins="*", cors_methods=["post"]), secrets=['CHRONOMAPS_API_URL', 'OPENAI_API_KEY'], memory=options.MemoryOption.GB_16)
 def cluster_screenshots(req: https_fn.Request) -> https_fn.Response:
     # Get the request data
     # Workspace and api_key from query parameters:
@@ -227,7 +227,7 @@ def enhance_all(req: https_fn.Request) -> https_fn.Response:
             yield f"data: {json.dumps([delta, bit], ensure_ascii=False)}\n\n"
     return https_fn.Response(generate(), status=200, mimetype='text/event-stream')
 
-@scheduler_fn.on_schedule(region='europe-west1', schedule="every 5 minutes", secrets=['CHRONOMAPS_API_URL', 'OPENAI_API_KEY', 'CONFIG__ITS_TIME'], memory=options.MemoryOption.GB_8)
+@scheduler_fn.on_schedule(region='europe-west1', schedule="every 5 minutes", secrets=['CHRONOMAPS_API_URL', 'OPENAI_API_KEY', 'CONFIG__ITS_TIME'], memory=options.MemoryOption.GB_16)
 def cluster_its_time(event: scheduler_fn.ScheduledEvent) -> None:
     config_tags_tuples = []
     print("STARTING clustering all workspaces")

--- a/functions/tests/test_cluster_screenshots.py
+++ b/functions/tests/test_cluster_screenshots.py
@@ -185,15 +185,103 @@ class TestPerplexity:
         assert TSNEParams(PERPLEXITY=20).perplexity_for(500) == 20
 
 
+def _response(payload, status=200):
+    resp = type('Resp', (), {})()
+    resp.status_code = status
+    resp.json = lambda: payload
+    def raise_for_status():
+        if status >= 400:
+            raise calc_tsne.requests.HTTPError(f'{status} error')
+    resp.raise_for_status = raise_for_status
+    return resp
+
+
+class TestItemsAreFetchedInPages:
+    """A large workspace's items are fetched page by page: one request for all
+    of them exceeds Cloud Run's 32 MB response limit, the body comes back
+    truncated, and the workspace fails to cluster on every run."""
+
+    def _serve(self, total, params, status=200):
+        # The API pages an ordered list by offset; the ids let us see what was kept.
+        all_items = [dict(_id=f'r{i}') for i in range(total)]
+        calls = []
+
+        def fake_get(url, req_params=None, headers=None):
+            if not url.endswith('/items'):
+                return _response(dict(title='WS'))
+            calls.append(dict(req_params))
+            start = req_params['page'] * req_params['page_size']
+            return _response(all_items[start:start + req_params['page_size']], status)
+
+        records = []
+        with patch.object(calc_tsne.requests, 'get', fake_get), \
+             patch.object(calc_tsne, 'ensure_analysis') as ensure:
+            ensure.return_value = iter(())
+            list(calc_tsne.load_records([('ws', 'key')], records, params))
+        fetched = ensure.call_args.args[0] if ensure.called else None
+        return calls, fetched
+
+    def test_pages_until_a_short_page(self):
+        params = TSNEParams(FETCH_PAGE_SIZE=200)   # TO_PLOT*2 = 690 wanted
+        calls, fetched = self._serve(450, params)
+        assert [c['page'] for c in calls] == [0, 1, 2]
+        assert all(c['page_size'] == 200 for c in calls)
+        assert [c['include_embedding'] for c in calls] == ['true'] * 3
+        assert [i['_id'] for i in fetched] == [f'r{i}' for i in range(450)]
+
+    def test_stops_once_enough_are_in_hand(self):
+        params = TSNEParams(FETCH_PAGE_SIZE=200)
+        calls, fetched = self._serve(5000, params)
+        assert [c['page'] for c in calls] == [0, 1, 2, 3]
+        assert len(fetched) == params.TO_PLOT * 2
+
+    def test_a_page_of_exactly_the_page_size_is_followed_by_an_empty_one(self):
+        params = TSNEParams(FETCH_PAGE_SIZE=200)
+        calls, fetched = self._serve(200, params)
+        assert [c['page'] for c in calls] == [0, 1]
+        assert len(fetched) == 200
+
+    def test_an_item_repeated_across_pages_is_kept_once(self):
+        params = TSNEParams(FETCH_PAGE_SIZE=2)
+        pages = [[dict(_id='a'), dict(_id='b')], [dict(_id='b'), dict(_id='c')], [dict(_id='d')]]
+
+        def fake_get(url, req_params=None, headers=None):
+            if not url.endswith('/items'):
+                return _response(dict(title='WS'))
+            return _response(pages[req_params['page']])
+
+        records = []
+        with patch.object(calc_tsne.requests, 'get', fake_get), \
+             patch.object(calc_tsne, 'ensure_analysis') as ensure:
+            ensure.return_value = iter(())
+            list(calc_tsne.load_records([('ws', 'key')], records, params))
+        assert [i['_id'] for i in ensure.call_args.args[0]] == ['a', 'b', 'c', 'd']
+
+    def test_an_http_error_is_raised_not_parsed(self):
+        # The batch loop catches it per workspace and reports the status,
+        # instead of a JSONDecodeError on a truncated body.
+        with pytest.raises(calc_tsne.requests.HTTPError):
+            self._serve(10, TSNEParams(FETCH_PAGE_SIZE=200), status=503)
+
+    def test_an_error_body_skips_the_workspace(self):
+        def fake_get(url, req_params=None, headers=None):
+            return _response(dict(error='nope') if url.endswith('/items') else dict(title='WS'))
+
+        records = []
+        with patch.object(calc_tsne.requests, 'get', fake_get), \
+             patch.object(calc_tsne, 'ensure_analysis') as ensure:
+            list(calc_tsne.load_records([('ws', 'key')], records, TSNEParams()))
+        ensure.assert_not_called()
+        assert records == []
+
+
 class TestAnalysisRunsRegardlessOfCount:
     """Embeddings and AI favorability/plausibility are backfilled for every
     fetched item, before the count decides whether t-SNE or the fallback runs."""
 
     def _load(self, items, params):
         def fake_get(url, req_params=None, headers=None):
-            resp = type('Resp', (), {})()
-            resp.json = (lambda: items) if url.endswith('/items') else (lambda: dict(title='WS'))
-            return resp
+            return _response(items if url.endswith('/items') else dict(title='WS'))
 
         records = []
         with patch.object(calc_tsne.requests, 'get', fake_get), \
@@ -207,7 +295,7 @@ class TestAnalysisRunsRegardlessOfCount:
                       future_scenario_description=f'd{i}') for i in range(3)]
         ensure, _ = self._load(items, _small_params())
         ensure.assert_called_once()
-        assert ensure.call_args.args[0] is items
+        assert ensure.call_args.args[0] == items
         assert len(ensure.call_args.args[0]) == 3
 
     def test_items_the_map_rejects_are_still_analysed(self):
@@ -216,5 +304,5 @@ class TestAnalysisRunsRegardlessOfCount:
         items = [dict(_id='r0', future_scenario_description='d0')]
         ensure, records = self._load(items, _small_params())
         ensure.assert_called_once()
-        assert ensure.call_args.args[0] is items
+        assert ensure.call_args.args[0] == items
         assert records == []


### PR DESCRIPTION
## Why

`cluster_its_time` has failed on workspace `ceaed215…` (the June 2025 Amsterdam "Imagining Futures" archive, 2364 records) on every 5-minute run since 3 September. `load_records` requested all `TO_PLOT*2` = 690 items in one call with embeddings; at ~63 KB per item that is ~43 MB, over Cloud Run's 32 MB response cap. The API logs `Response size was too large`, the clusterer receives a truncated body and raises `JSONDecodeError`. The per-workspace guard contains it, so the rest of the batch still runs, but that map has not been regenerated since.

No memory kills appear in the logs over the last three days, so the memory bump is headroom rather than a fix for this failure.

## What

- `fetch_items` pages the items request (`TSNEParams.FETCH_PAGE_SIZE` = 200, ~12 MB a page), stops at a short page or once `wanted` items are in hand, keeps an id once if offset paging repeats it, and calls `raise_for_status()` so an HTTP error is reported as such.
- `cluster_its_time` and `cluster_screenshots` go from 8 GB to 16 GB, in `functions.yaml` and the decorators.
- CLAUDE.md documents the response-size constraint.

## Verification

- `pytest tests/`: 338 passed (6 new tests for paging, dedupe, HTTP errors and error bodies).
- Ran the new `fetch_items` against the live API for the failing workspace: 690 items, all with embeddings, in 4 requests (~106 s, since the API loads the whole collection to serve each page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdJVewR1AJL695XKmu8RBx
